### PR TITLE
Download FFmpeg at build time instead of storing it in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-*ffmpeg filter=lfs diff=lfs merge=lfs -text
-*ffmpeg.exe filter=lfs diff=lfs merge=lfs -text
-feature/photos/ffmpeg-binaries/** filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Phovo is currently undergoing active development. Core logic, architecture, and 
 The project can be assembled in an environment which has been configured for Kotlin Multiplatform development, please follow the official guide:
 https://kotlinlang.org/docs/multiplatform/quickstart.html#set-up-the-environment
 
+The desktop build embeds an FFmpeg binary, used for thumbnail generation. It is downloaded and
+verified against a pinned SHA-256 on the first build, so that build needs network access. The
+archive is cached under `~/.gradle/caches/phovo-ffmpeg`, which survives `clean`, so later builds
+work offline. Only the binary for the platform running the build is fetched. The pinned builds, and
+notes on updating them, live in `build-logic`'s `FfmpegDistribution.kt`.
+
 ## Source Sets
 The Phovo project makes use of custom source sets to maximize code re-usability when certain features
 are supported only by a subset of platforms. To learn more about custom source sets visit:

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.compose.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
+    // Needed at execution time by ProvisionFfmpegTask, so these cannot be compileOnly.
+    implementation(libs.commons.compress)
+    runtimeOnly(libs.tukaani.xz)
     //implementation(libs.truth)
 }
 

--- a/build-logic/convention/src/main/kotlin/com/serratocreations/phovo/buildlogic/ffmpeg/FfmpegDistribution.kt
+++ b/build-logic/convention/src/main/kotlin/com/serratocreations/phovo/buildlogic/ffmpeg/FfmpegDistribution.kt
@@ -1,0 +1,144 @@
+package com.serratocreations.phovo.buildlogic.ffmpeg
+
+/**
+ * Archive layouts the provisioning task knows how to unpack.
+ */
+enum class FfmpegArchiveFormat {
+    ZIP,
+    TAR_XZ
+}
+
+/**
+ * A single pinned FFmpeg build: where to fetch it, what it must hash to, and the executable to pull
+ * out of the archive.
+ *
+ * The checksum is not a nicety. [FfmpegBinaries.MAC_ARM] is served from a host that sits behind a
+ * proof of work bot wall which intermittently answers with an HTML challenge page instead of the
+ * zip, and a build that trusted the response blindly would happily write that page out and mark it
+ * executable. Verifying the archive is what turns that into a loud failure.
+ */
+data class FfmpegDistribution(
+    val platform: String,
+    val url: String,
+    val sha256: String,
+    val format: FfmpegArchiveFormat,
+    val executableName: String
+)
+
+/**
+ * The pinned set of FFmpeg builds, one per supported desktop target.
+ *
+ * These used to live in the repository under Git LFS, which put roughly half a gigabyte of binaries
+ * against the LFS quota. They are downloaded and verified at build time instead.
+ *
+ * ## Updating
+ *
+ * Every entry is pinned by exact URL plus SHA-256, so a bump means changing both. Sources, all
+ * reachable from https://ffmpeg.org/download.html#build:
+ *
+ *  - Windows and Linux come from https://github.com/BtbN/FFmpeg-Builds. Pin to a **month end**
+ *    autobuild tag: BtbN prunes daily tags after roughly two weeks, but keeps the month end ones
+ *    (they currently go back to 2024-09), so a month end tag stays resolvable. Checksums for a
+ *    release are published as its `checksums.sha256` asset, so a bump does not require downloading
+ *    the archives.
+ *  - macOS x86_64 comes from https://evermeet.cx/ffmpeg/ as a version pinned zip. They publish only
+ *    a GPG signature, so compute the SHA-256 after downloading.
+ *  - macOS arm64 comes from https://www.osxexperts.net/. Version named zips stay available after
+ *    newer ones ship. Current checksums are listed on the page; older ones must be computed.
+ *
+ * ## Why 8.1 and not 9.0
+ *
+ * FFmpeg 9.0 is released and the two macOS sources ship it, but BtbN's build matrix only covers
+ * `master`, `n7.1` and `n8.1`, so there is no 9.0 release branch build for Windows or Linux. Taking
+ * 9.0 would mean either running a different major version on macOS than everywhere else, or moving
+ * Windows and Linux onto rolling `master` dev builds. 8.1 is the newest version available as a
+ * stable release build on all six targets. Once BtbN adds an `n9.0` branch, bumping is a matter of
+ * editing the URLs and checksums below.
+ */
+object FfmpegBinaries {
+
+    /**
+     * Reported by `ffmpeg -version`. The BtbN builds are 8.1.2, evermeet is 8.1.2 and osxexperts is
+     * 8.1, so this is the shared release branch rather than an exact patch level.
+     */
+    const val VERSION_BRANCH: String = "8.1"
+
+    private const val BTBN_RELEASE =
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-31-14-10"
+
+    private const val BTBN_BUILD = "ffmpeg-n8.1.2-34-g9b6c8969e0"
+
+    val MAC_ARM = FfmpegDistribution(
+        platform = "mac-arm",
+        url = "https://www.osxexperts.net/ffmpeg81arm.zip",
+        sha256 = "ebb82529562b71170807bbc6b0e7eb4f0b13af8cbb0e085bb9e8f6fe709598ad",
+        format = FfmpegArchiveFormat.ZIP,
+        executableName = "ffmpeg"
+    )
+
+    val MAC_X64 = FfmpegDistribution(
+        platform = "mac-x64",
+        url = "https://evermeet.cx/ffmpeg/ffmpeg-8.1.2.zip",
+        sha256 = "e91df72a1ee7c26606f90dd2dd4dcccc6a75140ff9ea6fdd50faae828b82ba69",
+        format = FfmpegArchiveFormat.ZIP,
+        executableName = "ffmpeg"
+    )
+
+    val WIN_X64 = FfmpegDistribution(
+        platform = "win-x64",
+        url = "$BTBN_RELEASE/$BTBN_BUILD-win64-gpl-8.1.zip",
+        sha256 = "cc4156d51387566ea8ba653fc3a04897bdf812fddf652428d9030bbf7ae24835",
+        format = FfmpegArchiveFormat.ZIP,
+        executableName = "ffmpeg.exe"
+    )
+
+    val WIN_ARM = FfmpegDistribution(
+        platform = "win-arm",
+        url = "$BTBN_RELEASE/$BTBN_BUILD-winarm64-gpl-8.1.zip",
+        sha256 = "abf3b41c200ce5346b9bb5be6fe634c4720d891778d8921f7b36b76d002b3c96",
+        format = FfmpegArchiveFormat.ZIP,
+        executableName = "ffmpeg.exe"
+    )
+
+    val LINUX_X64 = FfmpegDistribution(
+        platform = "linux-x64",
+        url = "$BTBN_RELEASE/$BTBN_BUILD-linux64-gpl-8.1.tar.xz",
+        sha256 = "09fc77be269c7053e438b7e96548e4af97604faf96a42c4a3c56a1ad74c22c0a",
+        format = FfmpegArchiveFormat.TAR_XZ,
+        executableName = "ffmpeg"
+    )
+
+    val LINUX_ARM = FfmpegDistribution(
+        platform = "linux-arm",
+        url = "$BTBN_RELEASE/$BTBN_BUILD-linuxarm64-gpl-8.1.tar.xz",
+        sha256 = "177e40c91564dec3840096f3bf1ffe696b94330585972462cfc739fa29fe0e1a",
+        format = FfmpegArchiveFormat.TAR_XZ,
+        executableName = "ffmpeg"
+    )
+
+    /**
+     * Picks the build matching the machine running the build. Only the host binary is provisioned,
+     * matching how the LFS based setup behaved: the desktop app embeds FFmpeg as a Compose resource,
+     * so a build produces an artifact for the platform it ran on.
+     */
+    fun forHost(
+        osName: String = System.getProperty("os.name"),
+        osArch: String = System.getProperty("os.arch")
+    ): FfmpegDistribution {
+        val os = osName.lowercase()
+        val arch = osArch.lowercase()
+        val isArm = arch.contains("aarch64") || arch.contains("arm")
+
+        return when {
+            os.contains("mac") && isArm -> MAC_ARM
+            os.contains("mac") -> MAC_X64
+            // Win32 support is possible by manually building the binary
+            // https://github.com/BtbN/FFmpeg-Builds/tree/latest
+            os.contains("win") && isArm -> WIN_ARM
+            os.contains("win") -> WIN_X64
+            os.contains("linux") && isArm -> LINUX_ARM
+            os.contains("linux") -> LINUX_X64
+            else -> error("Unsupported OS for FFmpeg provisioning: $osName $osArch")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/serratocreations/phovo/buildlogic/ffmpeg/ProvisionFfmpegTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/serratocreations/phovo/buildlogic/ffmpeg/ProvisionFfmpegTask.kt
@@ -1,0 +1,266 @@
+package com.serratocreations.phovo.buildlogic.ffmpeg
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.apache.commons.compress.compressors.xz.XZCompressorInputStream
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.InputStream
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.security.MessageDigest
+import java.time.Duration
+import java.util.zip.ZipFile
+
+/**
+ * Downloads the pinned FFmpeg build for the host platform, verifies it against its SHA-256, and
+ * unpacks the executable into `<outputDirectory>/files/` so Compose can pick it up as a custom
+ * resource directory.
+ *
+ * Replaces the previous Git LFS checkout of roughly half a gigabyte of committed binaries.
+ *
+ * Archives are cached under the Gradle user home rather than the build directory, so `clean` does
+ * not force another download. The cache is content addressed by checksum, which means bumping the
+ * pinned version can never collide with a previously cached archive of the same file name.
+ */
+@DisableCachingByDefault(
+    because = "Output is a single large binary that is cheaper to keep in the local archive cache " +
+        "than to move through the build cache"
+)
+abstract class ProvisionFfmpegTask : DefaultTask() {
+
+    @get:Input
+    abstract val downloadUrl: Property<String>
+
+    @get:Input
+    abstract val sha256: Property<String>
+
+    @get:Input
+    abstract val archiveFormat: Property<FfmpegArchiveFormat>
+
+    /** `ffmpeg`, or `ffmpeg.exe` on Windows. */
+    @get:Input
+    abstract val executableName: Property<String>
+
+    /** Named only for error messages, so a failure says which target it was provisioning. */
+    @get:Input
+    abstract val platform: Property<String>
+
+    /**
+     * Shared across builds and across `clean`, so this is deliberately not tracked as an input or
+     * an output: its contents are addressed by the checksum that is already an input.
+     */
+    @get:Internal
+    abstract val archiveCacheDirectory: DirectoryProperty
+
+    @get:Internal
+    abstract val offline: Property<Boolean>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun provision() {
+        val expectedSha = sha256.get().lowercase()
+        val archive = resolveArchive(expectedSha)
+
+        val filesDir = outputDirectory.get().asFile.resolve("files")
+        // Wipe first so a stale binary from another platform cannot survive here.
+        filesDir.deleteRecursively()
+        filesDir.mkdirs()
+
+        val target = filesDir.resolve(executableName.get())
+        extractExecutable(archive, target)
+        target.setExecutable(true, false)
+
+        logger.lifecycle("Provisioned FFmpeg ${FfmpegBinaries.VERSION_BRANCH} (${platform.get()}) at $target")
+    }
+
+    /**
+     * Returns a verified archive, downloading it only if the cache does not already hold one whose
+     * contents hash to [expectedSha].
+     */
+    private fun resolveArchive(expectedSha: String): File {
+        val cacheDir = archiveCacheDirectory.get().asFile
+        cacheDir.mkdirs()
+
+        val fileName = downloadUrl.get().substringAfterLast('/')
+        val cached = cacheDir.resolve("$expectedSha-$fileName")
+
+        // A cached archive is named for its own checksum, but rehash it anyway: a half written file
+        // from an interrupted build would otherwise be handed to the extractor.
+        if (cached.isFile && cached.sha256() == expectedSha) {
+            logger.info("Using cached FFmpeg archive $cached")
+            return cached
+        }
+        cached.delete()
+
+        if (offline.getOrElse(false)) {
+            throw GradleException(
+                "FFmpeg archive for ${platform.get()} is not in the cache at $cacheDir and Gradle " +
+                    "is running with --offline. Re-run without --offline to download it from " +
+                    "${downloadUrl.get()}."
+            )
+        }
+
+        download(cached, expectedSha)
+        return cached
+    }
+
+    private fun download(target: File, expectedSha: String) {
+        val url = downloadUrl.get()
+        val temp = File(target.parentFile, "${target.name}.part")
+        var lastFailure: Exception? = null
+
+        repeat(DOWNLOAD_ATTEMPTS) { attempt ->
+            temp.delete()
+            try {
+                logger.lifecycle(
+                    "Downloading FFmpeg ${FfmpegBinaries.VERSION_BRANCH} for ${platform.get()} from $url"
+                )
+                fetch(url, temp)
+
+                val actualSha = temp.sha256()
+                if (actualSha == expectedSha) {
+                    temp.renameTo(target)
+                    return
+                }
+
+                lastFailure = GradleException(checksumMismatchMessage(url, expectedSha, actualSha, temp.length()))
+            } catch (e: Exception) {
+                lastFailure = e
+            }
+
+            if (attempt < DOWNLOAD_ATTEMPTS - 1) {
+                logger.warn("FFmpeg download attempt ${attempt + 1} failed (${lastFailure?.message}), retrying")
+                Thread.sleep(RETRY_BACKOFF_MILLIS * (attempt + 1))
+            }
+        }
+
+        temp.delete()
+        throw GradleException(
+            "Failed to download a verified FFmpeg build for ${platform.get()} from $url after " +
+                "$DOWNLOAD_ATTEMPTS attempts.",
+            lastFailure
+        )
+    }
+
+    private fun fetch(url: String, target: File) {
+        val client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+            .build()
+
+        val request = HttpRequest.newBuilder(URI.create(url))
+            .header("User-Agent", USER_AGENT)
+            .timeout(Duration.ofMinutes(REQUEST_TIMEOUT_MINUTES))
+            .GET()
+            .build()
+
+        val response = client.send(request, HttpResponse.BodyHandlers.ofFile(target.toPath()))
+        if (response.statusCode() !in 200..299) {
+            throw GradleException("$url returned HTTP ${response.statusCode()}")
+        }
+    }
+
+    /**
+     * The macOS arm64 host answers with an HTML proof of work challenge when it decides a client
+     * looks automated, so a mismatch here is far more likely to be a challenge page than a corrupted
+     * download. Say so, otherwise the failure reads as an unexplained checksum error.
+     */
+    private fun checksumMismatchMessage(
+        url: String,
+        expected: String,
+        actual: String,
+        size: Long
+    ): String = buildString {
+        append("Checksum mismatch for $url\n")
+        append("  expected: $expected\n")
+        append("  actual:   $actual\n")
+        append("  size:     $size bytes\n")
+        append(
+            "The response was not the expected archive. This is usually a bot challenge or error " +
+                "page served in place of the download, or a source that republished the file under " +
+                "the same URL. Verify the download by hand before changing the pinned checksum."
+        )
+    }
+
+    private fun extractExecutable(archive: File, target: File) {
+        val executable = executableName.get()
+        val extracted = when (archiveFormat.get()) {
+            FfmpegArchiveFormat.ZIP -> extractFromZip(archive, executable, target)
+            FfmpegArchiveFormat.TAR_XZ -> extractFromTarXz(archive, executable, target)
+        }
+
+        if (!extracted) {
+            throw GradleException("No '$executable' entry found inside $archive")
+        }
+    }
+
+    private fun extractFromZip(archive: File, executable: String, target: File): Boolean =
+        ZipFile(archive).use { zip ->
+            val entry = zip.entries()
+                .asSequence()
+                .firstOrNull { !it.isDirectory && it.name.isExecutablePath(executable) }
+                ?: return@use false
+            zip.getInputStream(entry).use { it.writeTo(target) }
+            true
+        }
+
+    private fun extractFromTarXz(archive: File, executable: String, target: File): Boolean =
+        TarArchiveInputStream(XZCompressorInputStream(BufferedInputStream(archive.inputStream()))).use { tar ->
+            // `any` stops at the first match, leaving the stream positioned on that entry's data.
+            val found = generateSequence { tar.nextEntry }
+                .any { !it.isDirectory && it.name.isExecutablePath(executable) }
+            if (!found) return@use false
+            tar.writeTo(target)
+            true
+        }
+
+    /**
+     * Matches on the trailing path segment because the archives disagree about layout: the macOS
+     * zips hold a bare `ffmpeg` at the root while the BtbN archives nest it under
+     * `<build-name>/bin/`. `__MACOSX` holds resource fork stubs that share the file name.
+     */
+    private fun String.isExecutablePath(executable: String): Boolean =
+        !startsWith("__MACOSX/") && substringAfterLast('/') == executable
+
+    private fun InputStream.writeTo(target: File) {
+        target.outputStream().buffered().use { output -> copyTo(output) }
+    }
+
+    private fun File.sha256(): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        inputStream().buffered().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private companion object {
+        const val DOWNLOAD_ATTEMPTS = 3
+        const val RETRY_BACKOFF_MILLIS = 2_000L
+        const val CONNECT_TIMEOUT_SECONDS = 30L
+        const val REQUEST_TIMEOUT_MINUTES = 10L
+
+        /**
+         * Some of the sources reject or challenge clients that do not present a browser-ish agent.
+         */
+        const val USER_AGENT = "Phovo-Gradle-Build"
+    }
+}

--- a/data/thumbnails/build.gradle.kts
+++ b/data/thumbnails/build.gradle.kts
@@ -1,12 +1,6 @@
-import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.file.DirectoryProperty
+import com.serratocreations.phovo.buildlogic.ffmpeg.FfmpegBinaries
+import com.serratocreations.phovo.buildlogic.ffmpeg.ProvisionFfmpegTask
 import org.gradle.kotlin.dsl.sourceSets
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 plugins {
     alias(libs.plugins.phovo.kmp.desktop.library)
@@ -26,49 +20,27 @@ kotlin {
     }
 }
 
+// FFmpeg is downloaded and checksum verified at build time rather than committed through Git LFS,
+// which has quota limits. See FfmpegBinaries for the pinned builds and how to update them.
 compose.resources {
     publicResClass = true
     generateResClass = always
     customDirectory(
         sourceSetName = "jvmMain",
-        directoryProvider = tasks.register<CopyPlatformFFmpeg>("copyPlatformFFmpeg") {
-            val osName = System.getProperty("os.name").lowercase()
-            val arch = System.getProperty("os.arch").lowercase()
-            val isArm = arch.contains("aarch64") || arch.contains("arm")
+        directoryProvider = tasks.register<ProvisionFfmpegTask>("provisionFfmpeg") {
+            val distribution = FfmpegBinaries.forHost()
 
-            // For binary updates check https://ffmpeg.org/download.html
-            val ffmpegSourceFile = when {
-                osName.contains("mac") && isArm -> project.file("ffmpeg-binaries/mac-arm/ffmpeg")
-                osName.contains("mac") -> project.file("ffmpeg-binaries/mac-x64/ffmpeg")
-                // Win32 support is possible by manually building the binary https://github.com/BtbN/FFmpeg-Builds/tree/latest
-                osName.contains("win") && isArm -> project.file("ffmpeg-binaries/win-arm/ffmpeg.exe")
-                osName.contains("win") -> project.file("ffmpeg-binaries/win-x64/ffmpeg.exe")
+            platform.set(distribution.platform)
+            downloadUrl.set(distribution.url)
+            sha256.set(distribution.sha256)
+            archiveFormat.set(distribution.format)
+            executableName.set(distribution.executableName)
 
-                osName.contains("linux") && isArm -> project.file("ffmpeg-binaries/linux-arm/ffmpeg")
-                osName.contains("linux") -> project.file("ffmpeg-binaries/linux-x64/ffmpeg")
+            // Outside the build directory so `clean` does not force another download.
+            archiveCacheDirectory.set(gradle.gradleUserHomeDir.resolve("caches/phovo-ffmpeg"))
+            offline.set(gradle.startParameter.isOffline)
 
-                else -> error("Unsupported OS: $osName $arch")
-            }
-            ffmpegSource.set(ffmpegSourceFile)
-            outputDir.set(project.layout.buildDirectory.dir("generatedFfmpegResources"))
-        }.flatMap { it.outputDir }
+            outputDirectory.set(project.layout.buildDirectory.dir("generatedFfmpegResources"))
+        }.flatMap { it.outputDirectory }
     )
-}
-
-abstract class CopyPlatformFFmpeg : DefaultTask() {
-
-    @get:InputFile
-    abstract val ffmpegSource: RegularFileProperty
-
-    @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
-
-    @TaskAction
-    fun run() {
-        val sourceFile = ffmpegSource.get().asFile
-        val targetDir = outputDir.get().asFile.resolve("files")
-        targetDir.mkdirs()
-        Files.copy(sourceFile.toPath(), targetDir.resolve(sourceFile.name).toPath(), StandardCopyOption.REPLACE_EXISTING)
-        println("Copied FFmpeg to $targetDir")
-    }
 }

--- a/data/thumbnails/ffmpeg-binaries/linux-arm/ffmpeg
+++ b/data/thumbnails/ffmpeg-binaries/linux-arm/ffmpeg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5184d4c7ddf93d246da3c9a54daed333f65d2ebcc442957bd41df6c3308c4cc7
-size 89208224

--- a/data/thumbnails/ffmpeg-binaries/linux-x64/ffmpeg
+++ b/data/thumbnails/ffmpeg-binaries/linux-x64/ffmpeg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55dbb68fc44829a04b752b056ee41835a4711e68c0a2bd8dd3af5c532bb1459a
-size 111712200

--- a/data/thumbnails/ffmpeg-binaries/mac-arm/ffmpeg
+++ b/data/thumbnails/ffmpeg-binaries/mac-arm/ffmpeg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:011221d75eae36943b5a6a28f70e25928cfb5602fe616d06da0a3b9b55ff6b75
-size 50268776

--- a/data/thumbnails/ffmpeg-binaries/mac-x64/ffmpeg
+++ b/data/thumbnails/ffmpeg-binaries/mac-x64/ffmpeg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23fb76dd559e155e49b9808b86ab5117f297b76294a798e4ef6cbb12fd15a689
-size 79612272

--- a/data/thumbnails/ffmpeg-binaries/win-arm/ffmpeg.exe
+++ b/data/thumbnails/ffmpeg-binaries/win-arm/ffmpeg.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c546774b8ca5921ae28aa32c12e5e3943ebd5137590d5bfd1eb014943074da1
-size 60525056

--- a/data/thumbnails/ffmpeg-binaries/win-x64/ffmpeg.exe
+++ b/data/thumbnails/ffmpeg-binaries/win-x64/ffmpeg.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5895b66323d631494309db808dc953cb2de31c0870eeadead869ec3c56f5a413
-size 110036480

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,10 @@ serialization-json = "1.11.0"
 sqlite = "2.7.0"
 telephoto = "0.19.0"
 jmdns = "3.6.3"
+# Used by build-logic only, to unpack the FFmpeg archives downloaded at build time. The BtbN Linux
+# builds ship as .tar.xz, which neither the JDK nor Gradle's archive operations can read.
+commons-compress = "1.28.0"
+tukaani-xz = "1.12"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -135,6 +139,8 @@ compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin",
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room-kmp" }
+commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress" }
+tukaani-xz = { group = "org.tukaani", name = "xz", version.ref = "tukaani-xz" }
 
 [bundles]
 navigation3 = ["navigation3-runtime", "navigation3-ui", "androidx-lifecycle-viewmodel-navigation3", "androidx-material3-adaptive-navigation3"]


### PR DESCRIPTION
Fixes #56

The six committed FFmpeg builds took roughly half a gigabyte of Git LFS quota, which is limited. They are now downloaded from their upstream sources on first build and verified against a pinned SHA-256.

## What changed

- **`FfmpegDistribution.kt`** (new, in `build-logic`) — the pinned table: one entry per target with URL, SHA-256, archive format and executable name, plus host resolution. Carries the provenance notes and instructions for bumping versions.
- **`ProvisionFfmpegTask.kt`** (new) — downloads with retry, verifies, unpacks the executable, and writes it into the output directory.
- **`data/thumbnails/build.gradle.kts`** — same `customDirectory` + `Provider<Directory>` wiring as before, per the [Compose custom resource directories guidance](https://kotlinlang.org/docs/multiplatform/compose-multiplatform-resources-setup.html#custom-resource-directories). Only the source of that directory changed, so nothing downstream of the build is affected.
- Binaries and `.gitattributes` deleted; README notes the new network requirement.

Archives are cached under `~/.gradle/caches/phovo-ffmpeg`, addressed by checksum, so `clean` does not force another download and version bumps cannot collide with a stale cache entry. Only the host platform's binary is fetched, matching the previous behaviour.

## FFmpeg 7.1.1 → 8.1

8.1 is the newest version available as a stable release build across all six targets. FFmpeg 9.0 is released and both macOS sources ship it, but BtbN's build matrix only covers `master`, `n7.1` and `n8.1`, so there is no 9.0 release branch build for Windows or Linux. Taking 9.0 would mean either running a different major version on macOS than everywhere else, or moving Windows and Linux onto rolling `master` dev builds. Once BtbN adds an `n9.0` branch, bumping is a matter of editing the URLs and checksums.

Migrating the download from build time to runtime is tracked in #130.

## Notes for reviewers

**The checksum is load-bearing, not hygiene.** The macOS arm64 source (`osxexperts.net`) sits behind a proof of work bot wall that intermittently answers with an HTML challenge page instead of the zip — this happened once while researching the change. Without verification the build would write that page out and mark it executable. The mismatch error names that case explicitly so the failure is not read as a mysterious corrupt download.

**Why the pins point at month-end BtbN tags.** BtbN prunes daily autobuild tags after roughly two weeks but keeps the month-end ones, currently back to 2024-09. Pinning to a daily tag would break the build within a fortnight.

**New build-classpath dependencies.** `commons-compress` and `xz`, needed because the BtbN Linux builds ship as `.tar.xz`, which neither the JDK nor Gradle's archive operations can read. They are on the `build-logic` classpath only, not the app's.

**This does not reclaim the LFS quota.** The objects remain in history, so a separate history rewrite is still required, and is deliberately not tracked as an issue for now. Until that lands, `git lfs uninstall` should not be run locally, as checking out any pre-migration commit would fail.

## Verification

| Check | Result |
| --- | --- |
| Provision on host (mac-arm) | arm64 Mach-O, `ffmpeg version 8.1` |
| `.tar.xz` path (linux-arm) | ELF aarch64 — tested by temporarily repointing the task, then reverted |
| Task re-run | `UP-TO-DATE` |
| Output deleted, re-run | Reuses cached archive, no re-download |
| `--offline` with empty cache | Fails with an actionable message |
| Configuration cache | Entry stored, compatible |
| Packaging | 51MB binary at `composeResources/…/files/ffmpeg`, the exact path `Res.getUri("files/ffmpeg")` reads |
| `:data:thumbnails:build` | Passes |
| `:applicationContainers:desktopApp:assemble` | Passes |
| 7.1.1 → 8.1 upgrade | Both of the app's real command lines run against 8.1: exit 0, all four `.webp` outputs produced, no deprecation warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

