### PR TITLE
Resolve the server by identity instead of a stored IP address

### DIFF
--- a/applicationContainers/androidApp/src/main/AndroidManifest.xml
+++ b/applicationContainers/androidApp/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
-    <!--Todo investigate https for desktop server-->
     <!--TODO The attribute android:allowBackup is deprecated from Android 12 and higher and may be removed in future versions. Consider adding the attribute android:dataExtractionRules specifying an @xml resource which configures cloud backups and device transfers on Android 12 and higher.-->
     <!--TODO @deprecated This API will be deprecated in the future and will have no effect. Specify a Network Security Config file in addition to this API to prevent future breakage. @FlaggedApi(android.security.Flags.-->
     <application

--- a/core/database/schemas/com.serratocreations.phovo.core.database.PhovoDatabase/1.json
+++ b/core/database/schemas/com.serratocreations.phovo.core.database.PhovoDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "a745bb980c93461d9529a1712c1d3ed4",
+    "identityHash": "c2c0c5d58c18921680a497f07f5cdda9",
     "entities": [
       {
         "tableName": "ServerConfigEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `backup_directory` TEXT NOT NULL, `server_name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `backup_directory` TEXT NOT NULL, `server_name` TEXT NOT NULL, `server_id` TEXT NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -23,6 +23,12 @@
           {
             "fieldPath": "serverName",
             "columnName": "server_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -189,7 +195,7 @@
       },
       {
         "tableName": "ClientConfigEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `serverUrl` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `serverUrl` TEXT NOT NULL, `server_id` TEXT, `service_name` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -202,6 +208,16 @@
             "columnName": "serverUrl",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serviceName",
+            "columnName": "service_name",
+            "affinity": "TEXT"
           }
         ],
         "primaryKey": {
@@ -238,7 +254,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a745bb980c93461d9529a1712c1d3ed4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c2c0c5d58c18921680a497f07f5cdda9')"
     ]
   }
 }

--- a/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/dao/ClientConfigDao.kt
+++ b/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/dao/ClientConfigDao.kt
@@ -15,6 +15,24 @@ interface ClientConfigDao {
     @Query("SELECT * FROM ClientConfigEntity LIMIT 1")
     fun clientConfigFlow(): Flow<ClientConfigEntity?>
 
+    @Query("SELECT * FROM ClientConfigEntity LIMIT 1")
+    suspend fun getClientConfig(): ClientConfigEntity?
+
+    /**
+     * Updates only the cached address, leaving identity untouched. Kept separate from [insert] so
+     * that re-resolving an address cannot accidentally rewrite which server we are paired with.
+     */
+    @Query("UPDATE ClientConfigEntity SET serverUrl = :serverUrl WHERE id = 1")
+    suspend fun updateServerUrl(serverUrl: String)
+
+    /**
+     * Records the identity a server reported for a pairing made from a manually entered address,
+     * which starts with no identity. Without this such a pairing could never be re-resolved after
+     * the server's address changed.
+     */
+    @Query("UPDATE ClientConfigEntity SET server_id = :serverId WHERE id = 1 AND server_id IS NULL")
+    suspend fun adoptServerId(serverId: String)
+
     @Query("DELETE FROM ClientConfigEntity")
     suspend fun deleteConfig()
 }

--- a/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/entities/ClientConfigEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/entities/ClientConfigEntity.kt
@@ -1,5 +1,6 @@
 package com.serratocreations.phovo.core.database.entities
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -8,5 +9,21 @@ data class ClientConfigEntity(
     // Since only one server URL is active at a time, we use a single row
     // with a fixed primary key of 1 and an onConflict REPLACE strategy.
     @PrimaryKey val id: Long = 1,
-    val serverUrl: String
+    /**
+     * The last address the server was reachable at. This is a cache, not the identity of the
+     * connection — an address is a DHCP lease and is expected to change. [serverId] is what
+     * actually identifies the server, and the resolver rewrites this column whenever it finds the
+     * server somewhere new.
+     */
+    val serverUrl: String,
+    /**
+     * Identity of the paired server, as reported by its health endpoint and mDNS TXT record.
+     * Null only between a manual pairing being saved and its first successful health probe, after
+     * which the client adopts the identity the server reports.
+     */
+    @ColumnInfo(name = "server_id")
+    val serverId: String? = null,
+    /** mDNS service instance name, used as a hint when re-browsing for the server. */
+    @ColumnInfo(name = "service_name")
+    val serviceName: String? = null
 )

--- a/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/entities/ServerConfigEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/serratocreations/phovo/core/database/entities/ServerConfigEntity.kt
@@ -12,5 +12,11 @@ data class ServerConfigEntity(
     @ColumnInfo(name = "backup_directory")
     val backupDirectory: String,
     @ColumnInfo(name = "server_name")
-    val serverName: String
+    val serverName: String,
+    /**
+     * Stable identity for this server, generated once and preserved across reconfiguration.
+     * Clients persist it and use it to re-find this server after its address changes.
+     */
+    @ColumnInfo(name = "server_id")
+    val serverId: String
 )

--- a/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/ClientGetPhotosThumbnailsUseCase.kt
+++ b/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/ClientGetPhotosThumbnailsUseCase.kt
@@ -6,7 +6,8 @@ import com.serratocreations.phovo.core.domain.model.MediaItemWithThumbnails
 import com.serratocreations.phovo.core.logger.PhovoLogger
 import com.serratocreations.phovo.data.photos.repository.MediaRepository
 import com.serratocreations.phovo.data.photos.repository.model.AssetLocation
-import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.div
 import io.github.vinceglb.filekit.exists
@@ -21,7 +22,7 @@ import kotlinx.coroutines.flow.sample
 
 class ClientGetPhotosFeedWithThumbnailsUseCase(
     private val mediaRepository: MediaRepository,
-    private val serverConfigRepository: IosAndroidServerConfigRepository,
+    private val endpointResolver: ServerEndpointResolver,
     private val ioDispatcher: CoroutineDispatcher,
     logger: PhovoLogger
 ): GetPhotosFeedWithThumbnailsUseCase {
@@ -32,8 +33,10 @@ class ClientGetPhotosFeedWithThumbnailsUseCase(
         return combine(
             // Sampled upstream of the mapping below, see PHOTOS_FEED_SAMPLE_PERIOD
             mediaRepository.phovoMediaFlow().sample(PHOTOS_FEED_SAMPLE_PERIOD),
-            serverConfigRepository.observeServerConfig().distinctUntilChanged()
-        ) { mediaList, serverConfig ->
+            // Thumbnail URLs must point at wherever the server is *now*, so this tracks the
+            // resolved address rather than the stored config, which no longer carries one.
+            endpointResolver.state
+        ) { mediaList, connectionState ->
             return@combine mediaList.mapNotNull { mediaItem ->
                 // Prefer file thumb if exists, fallback to network thumb, no thumb if no base url
                 val lowResThumb = (FileKit.filesDir / LOW_RES_THUMBNAIL_DIR / "${mediaItem.uniqueAssetIdentifier}.webp").let {
@@ -62,7 +65,7 @@ class ClientGetPhotosFeedWithThumbnailsUseCase(
                     lowResThumbnailLocation = lowResThumb,
                     highResThumbnailLocation = highResThumb,
                     assetHash = mediaItem.uniqueAssetIdentifier,
-                    baseUrl = serverConfig?.serverBaseUrlString
+                    baseUrl = (connectionState as? ServerConnectionState.Connected)?.baseUrl
                 )
             }
         }.flowOn(ioDispatcher)

--- a/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/GetBackupStatusUseCase.kt
+++ b/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/GetBackupStatusUseCase.kt
@@ -2,6 +2,8 @@ package com.serratocreations.phovo.core.domain
 
 import com.serratocreations.phovo.core.domain.mapper.toBackupStatus
 import com.serratocreations.phovo.core.domain.model.BackupStatus
+import com.serratocreations.phovo.core.model.network.NetworkFailure
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
 import com.serratocreations.phovo.data.photos.LocalMediaManager
 import com.serratocreations.phovo.data.photos.repository.RemoteMediaRepositoryImpl
 import kotlinx.coroutines.flow.Flow
@@ -13,13 +15,21 @@ class GetBackupStatusUseCase(
 ) {
     operator fun invoke(): Flow<BackupStatus> {
         return combine(
-            remoteMediaRepository.observeServerConnection(),
+            remoteMediaRepository.observeConnectionState(),
             localMediaManager.localMediaState
-        ) { isServerConnected, localMediaState ->
-            if (isServerConnected.not()) {
-                BackupStatus.ServerOffline
-            } else {
-                localMediaState.toBackupStatus()
+        ) { connectionState, localMediaState ->
+            when (connectionState) {
+                is ServerConnectionState.Connected -> localMediaState.toBackupStatus()
+                is ServerConnectionState.Unreachable ->
+                    BackupStatus.ServerOffline(reason = connectionState.reason)
+                // Answering, but not the server we paired with — treated as offline so no photos
+                // are uploaded to it.
+                is ServerConnectionState.IdentityMismatch ->
+                    BackupStatus.ServerOffline(reason = NetworkFailure.Unreachable)
+                // Not configured, still checking, or currently being located — nothing to report.
+                ServerConnectionState.Unknown,
+                ServerConnectionState.Checking,
+                ServerConnectionState.Resolving -> BackupStatus.ServerOffline(reason = null)
             }
         }
     }

--- a/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/di/DomainModule.commonIosAndroid.kt
+++ b/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/di/DomainModule.commonIosAndroid.kt
@@ -18,7 +18,7 @@ internal actual val platformModule: Module = module {
     factory<GetPhotosFeedWithThumbnailsUseCase> {
         ClientGetPhotosFeedWithThumbnailsUseCase(
             mediaRepository = get(),
-            serverConfigRepository = get(),
+            endpointResolver = get(),
             ioDispatcher = get(IO_DISPATCHER),
             logger = get()
         )

--- a/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/model/BackupStatus.kt
+++ b/core/domain/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/domain/model/BackupStatus.kt
@@ -1,7 +1,12 @@
 package com.serratocreations.phovo.core.domain.model
 
+import com.serratocreations.phovo.core.model.network.NetworkFailure
+
 sealed interface BackupStatus {
-    data object ServerOffline: BackupStatus
+    /**
+     * @param reason why the server could not be reached, or null when no server is configured yet.
+     */
+    data class ServerOffline(val reason: NetworkFailure?): BackupStatus
 
     data object Scanning: BackupStatus
 

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/ServerConfig.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/ServerConfig.kt
@@ -18,7 +18,17 @@ sealed interface ServerConfig {
         val serverName: String
     ): ServerConfig
 
+    /**
+     * Identifies which server this client is paired with. Deliberately carries no address: an
+     * address is a lease that changes, and everything downstream of the config flow uses
+     * `flatMapLatest`, so including it here would tear down and restart the health poll and the
+     * media flow every time the server moved — blanking the photo feed on exactly the event this
+     * design exists to absorb. The current address is owned by the endpoint resolver instead.
+     *
+     * @param serverId null until a manually entered pairing completes its first health probe.
+     */
     data class ClientSpecificServerConfig(
-        val serverBaseUrlString: BaseUrl
+        val serverId: String?,
+        val serviceName: String?
     ): ServerConfig
 }

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ApiEndpoints.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ApiEndpoints.kt
@@ -3,7 +3,8 @@ package com.serratocreations.phovo.core.model.network
 import kotlin.jvm.JvmInline
 
 object ApiEndpoints {
-    val CHECK_ALIVE_API = Endpoint("")
+    /** Returns [ServerHealth]: liveness plus the identity a client verifies the server against. */
+    val HEALTH_API = Endpoint("health")
     val GET_ALL_MEDIA_API = Endpoint("all_media/")
     val LOW_RES_THUMBNAIL_API = Endpoint("low_res_thumbnails/")
     val HIGH_RES_THUMBNAIL_API = Endpoint("high_res_thumbnails/")

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/NetworkResult.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/NetworkResult.kt
@@ -4,6 +4,30 @@ sealed interface NetworkResult<out T> {
     data class NetworkSuccess<out T>(val data: T) : NetworkResult<T>
 
     data class NetworkError(
-        val message: String? = null
+        val message: String? = null,
+        val failure: NetworkFailure = NetworkFailure.Unknown,
+        val statusCode: Int? = null
     ): NetworkResult<Nothing>
+}
+
+/**
+ * Machine readable classification of a failed network call. [NetworkResult.NetworkError.message]
+ * remains a human readable description; callers that need to branch on the kind of failure should
+ * use this instead of parsing that string.
+ */
+enum class NetworkFailure {
+    /** The server could not be contacted at all — refused, host down, address unresolvable. */
+    Unreachable,
+
+    /** The connection or request exceeded its timeout. */
+    Timeout,
+
+    /** The server answered, but with a non 2xx status. See [NetworkResult.NetworkError.statusCode]. */
+    HttpStatus,
+
+    /** The server answered successfully but the body could not be parsed. */
+    Malformed,
+
+    /** Unclassified. Inspect [NetworkResult.NetworkError.message], which carries the exception type. */
+    Unknown
 }

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerAdvertisement.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerAdvertisement.kt
@@ -1,0 +1,63 @@
+package com.serratocreations.phovo.core.model.network
+
+/**
+ * What a Phovo server publishes about itself in its mDNS TXT record, and what a client reads back.
+ *
+ * Both the encoder (desktop, JmDNS) and the decoders (Android NsdManager, iOS NSNetService) live on
+ * opposite sides of the wire and in different source sets, so the key names and the codec are kept
+ * here — in shared code — to stop the two ends from drifting apart silently.
+ */
+data class ServerAdvertisement(
+    val serverId: String,
+    val serverName: String?,
+    val protocolVersion: Int,
+    val scheme: String,
+    /** Every address the server believes it is reachable on, in the order it prefers them. */
+    val addresses: List<String>
+)
+
+object ServerTxtRecord {
+    const val KEY_ID = "id"
+    const val KEY_PROTOCOL_VERSION = "v"
+    const val KEY_NAME = "name"
+    const val KEY_SCHEME = "scheme"
+    const val KEY_ADDRESSES = "addrs"
+
+    const val SCHEME_HTTP = "http"
+
+    private const val ADDRESS_SEPARATOR = ","
+
+    fun encode(
+        serverId: String,
+        serverName: String,
+        addresses: List<String>,
+        scheme: String = SCHEME_HTTP,
+        protocolVersion: Int = PhovoProtocol.VERSION
+    ): Map<String, String> = mapOf(
+        KEY_ID to serverId,
+        KEY_PROTOCOL_VERSION to protocolVersion.toString(),
+        KEY_NAME to serverName,
+        KEY_SCHEME to scheme,
+        KEY_ADDRESSES to addresses.joinToString(ADDRESS_SEPARATOR)
+    )
+
+    /**
+     * @return null when the record carries no usable identity — a malformed or truncated TXT
+     * record, or some other `_phovo._tcp` responder. Such a service cannot be matched to a paired
+     * server and should be ignored.
+     */
+    fun decode(properties: Map<String, String?>): ServerAdvertisement? {
+        val serverId = properties[KEY_ID]?.takeIf { it.isNotBlank() } ?: return null
+        return ServerAdvertisement(
+            serverId = serverId,
+            serverName = properties[KEY_NAME]?.takeIf { it.isNotBlank() },
+            protocolVersion = properties[KEY_PROTOCOL_VERSION]?.toIntOrNull() ?: PhovoProtocol.VERSION,
+            scheme = properties[KEY_SCHEME]?.takeIf { it.isNotBlank() } ?: SCHEME_HTTP,
+            addresses = properties[KEY_ADDRESSES]
+                ?.split(ADDRESS_SEPARATOR)
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                .orEmpty()
+        )
+    }
+}

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerConnectionState.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerConnectionState.kt
@@ -1,0 +1,41 @@
+package com.serratocreations.phovo.core.model.network
+
+/**
+ * The client's view of its connection to the Phovo server.
+ *
+ * This replaces a bare `Boolean`, which could not distinguish "no server configured yet" from
+ * "configured but the server is down" — both surfaced as a red status dot. Consumers that only
+ * need to know whether traffic can flow should use [isConnected] rather than matching exhaustively,
+ * so that later additions to this hierarchy do not become breaking changes.
+ */
+sealed interface ServerConnectionState {
+    /** No server is configured, or the first reachability check has not completed yet. */
+    data object Unknown : ServerConnectionState
+
+    /** A reachability check is currently in flight. */
+    data object Checking : ServerConnectionState
+
+    /** The cached address failed and the server is being looked up over mDNS. */
+    data object Resolving : ServerConnectionState
+
+    /** The server answered and is ready to serve requests at [baseUrl]. */
+    data class Connected(val baseUrl: BaseUrl) : ServerConnectionState
+
+    /** The server is configured but could not be reached. */
+    data class Unreachable(val reason: NetworkFailure) : ServerConnectionState
+
+    /**
+     * Something answered at the expected address, but it is not the server this client paired
+     * with — typically a DHCP reshuffle handing the old address to a different machine.
+     *
+     * Unlike [Unreachable] this is not transient and will not heal by retrying, so callers must
+     * stop polling the address rather than hammering a stranger's machine. It must also block
+     * uploads: the whole point of verifying identity is not to send someone's photos elsewhere.
+     */
+    data class IdentityMismatch(
+        val expectedServerId: String,
+        val actualServerId: String?
+    ) : ServerConnectionState
+
+    val isConnected: Boolean get() = this is Connected
+}

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerHealth.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerHealth.kt
@@ -1,0 +1,22 @@
+package com.serratocreations.phovo.core.model.network
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The server's response to a health probe.
+ *
+ * [serverId] is the value that makes a client's stored connection durable: it identifies the
+ * server independently of whatever address it currently holds, so a client can tell "my server
+ * moved" apart from "some other machine now answers on that address".
+ */
+@Serializable
+data class ServerHealth(
+    val serverId: String,
+    val serverName: String,
+    val protocolVersion: Int = PhovoProtocol.VERSION
+)
+
+object PhovoProtocol {
+    /** Bumped when the client/server contract changes in a way older peers cannot handle. */
+    const val VERSION = 1
+}

--- a/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerUrlNormalizer.kt
+++ b/core/model/src/commonMain/kotlin/com.serratocreations.phovo.core.model/network/ServerUrlNormalizer.kt
@@ -1,0 +1,54 @@
+package com.serratocreations.phovo.core.model.network
+
+/**
+ * Normalises a user typed server address into `scheme://host[:port]`.
+ *
+ * Manual entry is free text, and [BaseUrl.div] is a plain concatenation, so an unnormalised value
+ * fails later in ways that read as "the server is unreachable": a trailing slash produces `//` in
+ * every request path, and a missing scheme produces a URL that never resolves.
+ *
+ * @return the normalised address, or null when [input] cannot be a server address.
+ */
+fun normalizeServerUrl(input: String): String? {
+    val trimmed = input.trim().trimEnd('/')
+    if (trimmed.isEmpty()) return null
+
+    val schemeSeparator = trimmed.indexOf("://")
+    val scheme: String
+    val remainder: String
+    if (schemeSeparator == -1) {
+        scheme = "http"
+        remainder = trimmed
+    } else {
+        scheme = trimmed.substring(0, schemeSeparator).lowercase()
+        remainder = trimmed.substring(schemeSeparator + 3)
+        if (scheme != "http" && scheme != "https") return null
+    }
+
+    // Anything past the authority is a path, which a base URL must not carry.
+    val authority = remainder.substringBefore('/').substringBefore('?')
+    if (authority.isEmpty()) return null
+
+    val host: String
+    val port: String?
+    if (authority.startsWith("[")) {
+        // Bracketed IPv6 literal, e.g. [fe80::1]:8080
+        val closingBracket = authority.indexOf(']')
+        if (closingBracket == -1) return null
+        host = authority.substring(0, closingBracket + 1)
+        val rest = authority.substring(closingBracket + 1)
+        port = if (rest.startsWith(":")) rest.drop(1) else if (rest.isEmpty()) null else return null
+    } else if (authority.count { it == ':' } > 1) {
+        // Unbracketed IPv6 literal — bracket it so it is usable in a URL authority.
+        host = "[$authority]"
+        port = null
+    } else {
+        host = authority.substringBefore(':')
+        port = authority.substringAfter(':', missingDelimiterValue = "").takeIf { it.isNotEmpty() }
+    }
+
+    if (host.isEmpty() || host == "[]") return null
+    if (port != null && (port.toIntOrNull() ?: return null) !in 1..65535) return null
+
+    return if (port == null) "$scheme://$host" else "$scheme://$host:$port"
+}

--- a/core/serverconfig/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/serverconfig/IosAndroidServerConfigRepository.kt
+++ b/core/serverconfig/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/serverconfig/IosAndroidServerConfigRepository.kt
@@ -5,27 +5,58 @@ import com.serratocreations.phovo.core.database.entities.ClientConfigEntity
 import com.serratocreations.phovo.core.model.ServerConfig
 import com.serratocreations.phovo.core.model.network.BaseUrl
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 class IosAndroidServerConfigRepository(
     private val clientConfigDao: ClientConfigDao
 ) : ServerConfigRepository {
 
+    /**
+     * Emits the identity of the paired server. Address changes deliberately do not appear here —
+     * see [ServerConfig.ClientSpecificServerConfig] — so downstream `flatMapLatest` operators are
+     * not restarted when the server merely moves. Use [cachedServerUrl] for the address.
+     */
     override fun observeServerConfig(): Flow<ServerConfig.ClientSpecificServerConfig?> {
         return clientConfigDao.clientConfigFlow().map { entity ->
-            entity?.serverUrl?.let { url ->
+            entity?.let {
                 ServerConfig.ClientSpecificServerConfig(
-                    serverBaseUrlString = BaseUrl(url)
+                    serverId = it.serverId,
+                    serviceName = it.serviceName
                 )
             }
-        }
+        // Room re-emits on any write to the table, including one that only touched the cached
+        // address, so without this every re-resolution would still restart downstream flows.
+        }.distinctUntilChanged()
     }
 
-    override suspend fun updateClientServerConfig(serverUrl: String) {
-        clientConfigDao.insert(ClientConfigEntity(serverUrl = serverUrl))
+    /** The last address the server answered on, if any. */
+    suspend fun cachedServerUrl(): BaseUrl? =
+        clientConfigDao.getClientConfig()?.serverUrl?.let(::BaseUrl)
+
+    /** Records a newly resolved address without disturbing the stored identity. */
+    suspend fun updateCachedServerUrl(serverUrl: String) =
+        clientConfigDao.updateServerUrl(serverUrl)
+
+    /**
+     * Adopts the identity a server reported, for a pairing created without one. No-op once an
+     * identity is stored, so this can never silently repoint the client at a different server.
+     */
+    suspend fun adoptServerId(serverId: String) = clientConfigDao.adoptServerId(serverId)
+
+    override suspend fun updateClientServerConfig(
+        serverUrl: String,
+        serverId: String?,
+        serviceName: String?
+    ) {
+        clientConfigDao.insert(
+            ClientConfigEntity(
+                serverUrl = serverUrl,
+                serverId = serverId,
+                serviceName = serviceName
+            )
+        )
     }
 
-    override suspend fun clearClientServerConfig() {
-        clientConfigDao.deleteConfig()
-    }
+    override suspend fun clearClientServerConfig() = clientConfigDao.deleteConfig()
 }

--- a/core/serverconfig/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/serverconfig/ServerEndpointResolver.kt
+++ b/core/serverconfig/src/commonIosAndroid/kotlin/com/serratocreations/phovo/core/serverconfig/ServerEndpointResolver.kt
@@ -1,0 +1,30 @@
+package com.serratocreations.phovo.core.serverconfig
+
+import com.serratocreations.phovo.core.model.network.BaseUrl
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Finds the address of the server this client is paired with.
+ *
+ * The client persists *which* server it belongs to, not *where* it is. This resolves the second
+ * from the first: it tries the cached address, verifies the identity that answers, and re-browses
+ * mDNS when that fails. That is what makes a DHCP change, a move between Wi-Fi and Ethernet, or a
+ * router reboot recoverable without the user re-pairing.
+ *
+ * Implementations must be safe to call from many callers at once — the sync workers all fail
+ * together — and must not turn a burst of failures into a burst of mDNS browses.
+ */
+interface ServerEndpointResolver {
+    /** Current view of the connection, including which address is in use when connected. */
+    val state: StateFlow<ServerConnectionState>
+
+    /**
+     * @param force skip the cached address and re-browse, subject to rate limiting.
+     * @return the base URL to use, or null if the server could not be located.
+     */
+    suspend fun resolve(force: Boolean = false): BaseUrl?
+
+    /** Signals that the address previously handed out stopped working. */
+    fun invalidate()
+}

--- a/core/serverconfig/src/commonMain/kotlin/com/serratocreations/phovo/core/serverconfig/ServerConfigRepository.kt
+++ b/core/serverconfig/src/commonMain/kotlin/com/serratocreations/phovo/core/serverconfig/ServerConfigRepository.kt
@@ -5,6 +5,21 @@ import kotlinx.coroutines.flow.Flow
 
 interface ServerConfigRepository {
     fun observeServerConfig(): Flow<ServerConfig?>
-    suspend fun updateClientServerConfig(serverUrl: String)
+
+    /**
+     * Pairs this client with a server.
+     *
+     * @param serverUrl the address the server was reachable at when pairing. Stored only as a
+     * starting point; [serverId] is what the connection is actually keyed on.
+     * @param serverId null when pairing from a manually entered address, where no identity is
+     * known until the first health probe succeeds and the client adopts what the server reports.
+     * @param serviceName mDNS service instance name, used as a hint when re-browsing.
+     */
+    suspend fun updateClientServerConfig(
+        serverUrl: String,
+        serverId: String? = null,
+        serviceName: String? = null
+    )
+
     suspend fun clearClientServerConfig()
 }

--- a/core/serverconfig/src/jvmMain/kotlin/com/serratocreations/phovo/core/serverconfig/DesktopServerConfigRepository.kt
+++ b/core/serverconfig/src/jvmMain/kotlin/com/serratocreations/phovo/core/serverconfig/DesktopServerConfigRepository.kt
@@ -5,20 +5,40 @@ import com.serratocreations.phovo.core.model.ServerConfig
 import com.serratocreations.phovo.core.serverconfig.mapper.asEntity
 import com.serratocreations.phovo.core.serverconfig.mapper.asServerSpecificServerConfig
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.util.UUID
 
 class DesktopServerConfigRepository(
     private val localDataSource: ServerConfigDao
 ): ServerConfigRepository {
+    /**
+     * Writes the config, preserving the existing server identity if there is one. Regenerating the
+     * id would make every already-paired client see a different server, so it is minted exactly
+     * once — on the first configuration — and carried forward on every write after that.
+     */
     suspend fun updateServerConfig(serverConfig: ServerConfig.ServerSpecificServerConfig) =
-        localDataSource.insert(serverConfig.asEntity())
+        localDataSource.insert(
+            serverConfig.asEntity(serverId = serverId() ?: UUID.randomUUID().toString())
+        )
+
+    /**
+     * This server's stable identity, or null if the device has not been configured as a server yet.
+     * Only [updateServerConfig] mints one; this never creates, so that two callers racing before
+     * configuration cannot end up with different ids.
+     */
+    suspend fun serverId(): String? = localDataSource.serverConfigFlow().first()?.serverId
 
     override fun observeServerConfig(): Flow<ServerConfig.ServerSpecificServerConfig?> = localDataSource.serverConfigFlow()
         .map { serverConfigEntity ->
             serverConfigEntity?.asServerSpecificServerConfig()
         }
 
-    override suspend fun updateClientServerConfig(serverUrl: String) {
+    override suspend fun updateClientServerConfig(
+        serverUrl: String,
+        serverId: String?,
+        serviceName: String?
+    ) {
         // No-op for desktop server target
     }
 

--- a/core/serverconfig/src/jvmMain/kotlin/com/serratocreations/phovo/core/serverconfig/mapper/ServerConfigMapper.kt
+++ b/core/serverconfig/src/jvmMain/kotlin/com/serratocreations/phovo/core/serverconfig/mapper/ServerConfigMapper.kt
@@ -5,9 +5,10 @@ import com.serratocreations.phovo.core.model.ServerConfig
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.absolutePath
 
-fun ServerConfig.ServerSpecificServerConfig.asEntity() = ServerConfigEntity(
+fun ServerConfig.ServerSpecificServerConfig.asEntity(serverId: String) = ServerConfigEntity(
     backupDirectory = this.backupDirectory.absolutePath(),
-    serverName = this.serverName
+    serverName = this.serverName,
+    serverId = serverId
 )
 
 fun ServerConfigEntity.asServerSpecificServerConfig() = ServerConfig.ServerSpecificServerConfig(

--- a/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/di/PhotosDataPlatformModule.iosandroid.kt
+++ b/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/di/PhotosDataPlatformModule.iosandroid.kt
@@ -23,6 +23,7 @@ internal actual fun getAndroidDesktopIosModules(): Module = module {
         RemoteMediaRepositoryImpl(
             remotePhotosDataSource = get(),
             serverConfigRepository = get(),
+            endpointResolver = get(),
             applicationScope = get(APPLICATION_SCOPE),
             logger = get()
         )

--- a/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/network/MediaNetworkDataSource.kt
+++ b/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/network/MediaNetworkDataSource.kt
@@ -50,18 +50,6 @@ abstract class MediaNetworkDataSource(
         }
     }
 
-    /**
-     * Returns true if a connection to the server is successfully established,
-     * otherwise returns false. Connection can fail for a variety of reasons and this API does not
-     * currently return a failure reason.
-     */
-    suspend fun checkServerConnection(baseUrl: BaseUrl): Boolean {
-        val result = networkCallWrapper {
-            client.get(baseUrl / ApiEndpoints.CHECK_ALIVE_API)
-        }
-        return result is NetworkResult.NetworkSuccess
-    }
-
     suspend fun syncMedia(
         mediaItemDto: MediaItemDto,
         mediaUri: String,

--- a/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/network/util/NetworkCallWrappers.kt
+++ b/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/network/util/NetworkCallWrappers.kt
@@ -1,22 +1,46 @@
 package com.serratocreations.phovo.data.photos.network.util
 
 import com.serratocreations.phovo.core.model.network.NetworkCallRetryPolicy
+import com.serratocreations.phovo.core.model.network.NetworkFailure
 import com.serratocreations.phovo.core.model.network.NetworkResult
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
+
+/**
+ * Classifies a failed network call.
+ *
+ * Ktor's timeout exceptions all extend [IOException], so they are separated out first to
+ * distinguish a slow server from an absent one. [SerializationException] is an
+ * `IllegalArgumentException`, as is `UnresolvedAddressException` on JVM targets — neither is an
+ * [IOException], which is why the catch below cannot be narrowed to that type.
+ */
+private fun classifyNetworkFailure(e: Throwable): NetworkFailure = when (e) {
+    is HttpRequestTimeoutException,
+    is ConnectTimeoutException,
+    is SocketTimeoutException -> NetworkFailure.Timeout
+    is SerializationException -> NetworkFailure.Malformed
+    is IOException -> NetworkFailure.Unreachable
+    else -> NetworkFailure.Unknown
+}
 
 suspend fun <T> networkResultCallWrapper(
     retryPolicy: NetworkCallRetryPolicy = NetworkCallRetryPolicy.NONE,
     networkCall: suspend () -> NetworkResult<T>
 ): NetworkResult<T> {
-    suspend fun getResult() = try {
+    suspend fun getResult(): NetworkResult<T> = try {
         networkCall()
+    } catch (e: CancellationException) {
+        // Never convert cancellation into a failure result, it must propagate to the caller.
+        throw e
     } catch (e: Exception) {
-        when (e) {
-            is IOException -> NetworkResult.NetworkError(message = "$e")
-            else -> throw e
-        }
+        // "$e" retains the exception type, which is the only diagnostic for NetworkFailure.Unknown.
+        NetworkResult.NetworkError(message = "$e", failure = classifyNetworkFailure(e))
     }
 
     var result: NetworkResult<T> = getResult()
@@ -44,7 +68,10 @@ suspend fun networkCallWrapper(
         if (result.status.isSuccess()) {
             NetworkResult.NetworkSuccess(result)
         } else {
-            val message = "Network call failed with status: ${result.status}"
-            NetworkResult.NetworkError(message = message)
+            NetworkResult.NetworkError(
+                message = "Network call failed with status: ${result.status}",
+                failure = NetworkFailure.HttpStatus,
+                statusCode = result.status.value
+            )
         }
     }

--- a/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/repository/LocalAndRemoteMediaRepository.kt
+++ b/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/repository/LocalAndRemoteMediaRepository.kt
@@ -253,6 +253,8 @@ class LocalAndRemoteMediaRepositoryImpl(
         mediaUri: String
     ) = remoteMediaRepository.syncMedia(media, mediaUri)
 
+    override fun observeConnectionState() = remoteMediaRepository.observeConnectionState()
+
     override fun observeServerConnection() = remoteMediaRepository.observeServerConnection()
 
     override suspend fun getMediaItemByAssetHash(assetHash: String) = localMediaRepository.getMediaItemByAssetHash(assetHash)

--- a/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/repository/RemoteMediaRepository.kt
+++ b/data/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/photos/repository/RemoteMediaRepository.kt
@@ -3,31 +3,38 @@ package com.serratocreations.phovo.data.photos.repository
 import com.serratocreations.phovo.core.logger.PhovoLogger
 import com.serratocreations.phovo.core.model.network.MediaItemDto
 import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
 import com.serratocreations.phovo.data.photos.network.MediaNetworkDataSource
 import com.serratocreations.phovo.core.model.network.NetworkCallRetryPolicy
 import com.serratocreations.phovo.core.model.network.NetworkResult
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
 import com.serratocreations.phovo.data.photos.repository.model.MediaItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import kotlin.time.Duration.Companion.seconds
 
 class RemoteMediaRepositoryImpl(
     private val remotePhotosDataSource: MediaNetworkDataSource,
     private val serverConfigRepository: IosAndroidServerConfigRepository,
+    private val endpointResolver: ServerEndpointResolver,
     applicationScope: CoroutineScope,
     logger: PhovoLogger
 ): RemoteMediaRepository {
@@ -37,13 +44,40 @@ class RemoteMediaRepositoryImpl(
         private val CHECK_ALIVE_DELAY = 15.seconds
     }
 
+    init {
+        // TODO: Most likely there is a more sophisticated networking method to check alive
+        //  then pinging every X seconds(Investigate)
+        applicationScope.launch {
+            // Keyed on identity, not address, so re-resolving does not restart the poll.
+            serverConfigRepository.observeServerConfig().collectLatest { serverConfig ->
+                if (serverConfig == null) return@collectLatest
+                while (currentCoroutineContext().isActive) {
+                    yield()
+                    // Drop the memoised endpoint so the address is genuinely re-probed; the
+                    // resolver falls through to an mDNS browse if it stopped answering.
+                    endpointResolver.invalidate()
+                    endpointResolver.resolve()
+                    delay(CHECK_ALIVE_DELAY)
+                }
+            }
+        }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun phovoMediaFlow(): Flow<List<MediaItem>> {
-        return serverConfigRepository.observeServerConfig().flatMapLatest {
-            it?.serverBaseUrlString?.let { serverUrlNotNull ->
-                remotePhotosDataSource.allItemsFlow(serverUrlNotNull)
-                    .onStart { emit(emptyList()) }
-            } ?: flowOf(emptyList())
+        return serverConfigRepository.observeServerConfig().flatMapLatest { serverConfig ->
+            if (serverConfig == null) {
+                flowOf(emptyList())
+            } else {
+                flow {
+                    val baseUrl = endpointResolver.resolve()
+                    if (baseUrl == null) {
+                        emit(emptyList())
+                    } else {
+                        emitAll(remotePhotosDataSource.allItemsFlow(baseUrl))
+                    }
+                }.onStart { emit(emptyList()) }
+            }
         }
     }
 
@@ -51,9 +85,9 @@ class RemoteMediaRepositoryImpl(
         media: MediaItemDto,
         mediaUri: String
     ): NetworkResult<Unit> {
-        val baseUrl = serverConfigRepository.observeServerConfig().first()?.serverBaseUrlString
+        val baseUrl = endpointResolver.resolve()
         if (baseUrl == null) {
-            val errorMessage = "syncMedia failed because baseUrl is null"
+            val errorMessage = "syncMedia failed because the server could not be located"
             log.i { errorMessage }
             return NetworkResult.NetworkError(errorMessage)
         }
@@ -69,28 +103,14 @@ class RemoteMediaRepositoryImpl(
         )
     }
 
-    // TODO: Most likely there is a more sophisticated networking method to check alive
-    //  then pinging every X seconds(Investigate)
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private val isSeverConnected = serverConfigRepository.observeServerConfig().flatMapLatest {
-        flow {
-            if (it?.serverBaseUrlString == null) {
-                emit(false)
-            } else {
-                while(currentCoroutineContext().isActive) {
-                    yield()
-                    emit(remotePhotosDataSource.checkServerConnection(it.serverBaseUrlString))
-                    delay(CHECK_ALIVE_DELAY)
-                }
-            }
-        }
-    }.shareIn(
-        scope = applicationScope,
-        started = SharingStarted.Lazily,
-        replay = 1
-    )
+    override fun observeConnectionState(): Flow<ServerConnectionState> = endpointResolver.state
 
-    override fun observeServerConnection(): Flow<Boolean> {
-        return isSeverConnected
-    }
+    /**
+     * Derived view of the connection for callers that only gate on whether traffic can flow.
+     * Kept as a plain Boolean so the sync gates keep their existing semantics.
+     */
+    private val isSeverConnected: Flow<Boolean> =
+        endpointResolver.state.map { it.isConnected }.distinctUntilChanged()
+
+    override fun observeServerConnection(): Flow<Boolean> = isSeverConnected
 }

--- a/data/photos/src/commonMain/kotlin/com/serratocreations/phovo/data/photos/repository/RemoteMediaRepository.kt
+++ b/data/photos/src/commonMain/kotlin/com/serratocreations/phovo/data/photos/repository/RemoteMediaRepository.kt
@@ -2,14 +2,22 @@ package com.serratocreations.phovo.data.photos.repository
 
 import com.serratocreations.phovo.core.model.network.MediaItemDto
 import com.serratocreations.phovo.core.model.network.NetworkResult
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
 import kotlinx.coroutines.flow.Flow
 
 interface RemoteMediaRepository: MediaRepository {
     suspend fun syncMedia(media: MediaItemDto, mediaUri: String): NetworkResult<Unit>
 
     /**
-     * Observes the status of the connection to the phovo server by periodically
-     * pinging the server endpoint
+     * Observes the connection to the phovo server by periodically pinging the server endpoint.
+     * Prefer this over [observeServerConnection] when the reason for a failure matters, or when
+     * "not configured" needs to be told apart from "configured but down".
+     */
+    fun observeConnectionState(): Flow<ServerConnectionState>
+
+    /**
+     * Observes whether requests to the server can currently succeed. A convenience view of
+     * [observeConnectionState] for callers that only need to gate work on connectivity.
      */
     fun observeServerConnection(): Flow<Boolean>
 }

--- a/data/server/build.gradle.kts
+++ b/data/server/build.gradle.kts
@@ -21,6 +21,13 @@ kotlin {
             implementation(libs.filekit.core)
         }
 
+        commonIosAndroid.dependencies {
+            // The endpoint resolver probes the server's health endpoint while resolving.
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization)
+        }
+
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/data/server/src/androidMain/kotlin/com/serratocreations/phovo/data/server/AndroidServerDiscoveryManager.kt
+++ b/data/server/src/androidMain/kotlin/com/serratocreations/phovo/data/server/AndroidServerDiscoveryManager.kt
@@ -6,6 +6,7 @@ import android.net.nsd.NsdServiceInfo
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.serratocreations.phovo.core.logger.PhovoLogger
+import com.serratocreations.phovo.core.model.network.ServerTxtRecord
 import com.serratocreations.phovo.core.serverconfig.ServerConfigRepository
 import com.serratocreations.phovo.data.server.data.model.DiscoveredServer
 import kotlinx.coroutines.CoroutineScope
@@ -45,11 +46,7 @@ class AndroidServerDiscoveryManager(
                 val sanitizedHost = hostAddress.sanitizeHost()
                 log.i { "Service resolved: ${serviceInfo.serviceName} at $sanitizedHost:${serviceInfo.port}" }
 
-                val server = DiscoveredServer(
-                    name = serviceInfo.serviceName,
-                    ipAddress = sanitizedHost,
-                    port = serviceInfo.port
-                )
+                val server = serviceInfo.toDiscoveredServer(sanitizedHost)
 
                 launch {
                     discoveredServersMutex.withLock {
@@ -67,15 +64,15 @@ class AndroidServerDiscoveryManager(
             }
 
             override fun onServiceUpdated(resolvedInfo: NsdServiceInfo) {
-                val hostAddress = resolvedInfo.hostAddresses.firstOrNull()?.hostAddress ?: return
+                // Prefer IPv4: a bare IPv6 literal needs bracketing in a URL and is more likely to
+                // be unroutable on a home LAN.
+                val hostAddress = resolvedInfo.hostAddresses
+                    .sortedBy { it is java.net.Inet6Address }
+                    .firstOrNull()?.hostAddress ?: return
                 val sanitizedHost = hostAddress.sanitizeHost()
                 log.i { "Service updated: ${resolvedInfo.serviceName} at $sanitizedHost:${resolvedInfo.port}" }
 
-                val server = DiscoveredServer(
-                    name = resolvedInfo.serviceName,
-                    ipAddress = sanitizedHost,
-                    port = resolvedInfo.port
-                )
+                val server = resolvedInfo.toDiscoveredServer(sanitizedHost)
                 launch {
                     discoveredServersMutex.withLock {
                         discoveredServers[resolvedInfo.serviceName] = server
@@ -186,13 +183,36 @@ class AndroidServerDiscoveryManager(
     override fun discoverServers(): Flow<List<DiscoveredServer>> = serverDiscoverySharedFlow
 
     override suspend fun connectToServer(server: DiscoveredServer) {
-        log.i { "Connecting to discovered server: ${server.url}" }
-        serverConfigRepository.updateClientServerConfig(server.url)
+        log.i { "Connecting to discovered server: ${server.url} id: ${server.serverId}" }
+        serverConfigRepository.updateClientServerConfig(
+            serverUrl = server.url,
+            serverId = server.serverId,
+            serviceName = server.name
+        )
     }
 
     private fun String.sanitizeHost(): String {
         val result = if (this.startsWith("/")) this.substring(1) else this
         log.i { "sanitizeHost input $this output $result" }
         return result
+    }
+
+    /**
+     * NsdManager exposes TXT records as raw bytes; decode them so the identity the server
+     * advertises is available without an HTTP round trip.
+     */
+    private fun NsdServiceInfo.toDiscoveredServer(host: String): DiscoveredServer {
+        val properties = attributes.mapValues { (_, value) ->
+            value?.toString(Charsets.UTF_8)
+        }
+        val advertisement = ServerTxtRecord.decode(properties)
+        return DiscoveredServer(
+            name = serviceName,
+            ipAddress = host,
+            port = port,
+            serverId = advertisement?.serverId,
+            scheme = advertisement?.scheme ?: ServerTxtRecord.SCHEME_HTTP,
+            alternateAddresses = advertisement?.addresses.orEmpty().filterNot { it == host }
+        )
     }
 }

--- a/data/server/src/androidMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.android.kt
+++ b/data/server/src/androidMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.android.kt
@@ -3,8 +3,11 @@ package com.serratocreations.phovo.data.server.di
 import com.serratocreations.phovo.core.common.di.APPLICATION_SCOPE
 import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
 import com.serratocreations.phovo.core.serverconfig.ServerConfigRepository
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
 import com.serratocreations.phovo.data.server.AndroidServerDiscoveryManager
 import com.serratocreations.phovo.data.server.ServerDiscoveryManager
+import com.serratocreations.phovo.data.server.ServerEndpointResolverImpl
+import com.serratocreations.phovo.data.server.ServerHealthProbe
 import org.koin.core.module.Module
 import org.koin.dsl.binds
 import org.koin.dsl.module
@@ -17,6 +20,16 @@ internal actual fun getAndroidDesktopIosModules(): Module = module {
             get(),
             get(APPLICATION_SCOPE),
             get()
+        )
+    }
+    single { ServerHealthProbe(createHealthProbeClient()) }
+    single<ServerEndpointResolver> {
+        ServerEndpointResolverImpl(
+            serverConfigRepository = get(),
+            serverDiscoveryManager = get(),
+            healthProbe = get(),
+            applicationScope = get(APPLICATION_SCOPE),
+            logger = get()
         )
     }
 }

--- a/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/ServerEndpointResolverImpl.kt
+++ b/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/ServerEndpointResolverImpl.kt
@@ -1,0 +1,186 @@
+package com.serratocreations.phovo.data.server
+
+import com.serratocreations.phovo.core.logger.PhovoLogger
+import com.serratocreations.phovo.core.model.network.BaseUrl
+import com.serratocreations.phovo.core.model.network.NetworkFailure
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
+import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
+import com.serratocreations.phovo.data.server.data.model.DiscoveredServer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class ServerEndpointResolverImpl(
+    private val serverConfigRepository: IosAndroidServerConfigRepository,
+    private val serverDiscoveryManager: ServerDiscoveryManager,
+    private val healthProbe: ServerHealthProbe,
+    private val applicationScope: CoroutineScope,
+    logger: PhovoLogger
+) : ServerEndpointResolver {
+
+    private companion object {
+        /** How long to browse mDNS before giving up on finding the server. */
+        val DISCOVERY_TIMEOUT = 10.seconds
+
+        /**
+         * Floor on the gap between forced re-browses. Every sync worker calls invalidate() when its
+         * upload fails, so without this a single outage becomes an mDNS storm.
+         */
+        val MIN_REBROWSE_INTERVAL = 30.seconds
+    }
+
+    private val log = logger.withTag("ServerEndpointResolver")
+
+    private val _state = MutableStateFlow<ServerConnectionState>(ServerConnectionState.Unknown)
+    override val state = _state.asStateFlow()
+
+    private val resolveMutex = Mutex()
+    /** In-flight resolution, shared by every concurrent caller so one browse serves all of them. */
+    private var inFlight: Deferred<BaseUrl?>? = null
+    private var lastForcedBrowse: TimeSource.Monotonic.ValueTimeMark? = null
+    private var cachedEndpoint: BaseUrl? = null
+
+    override fun invalidate() {
+        cachedEndpoint = null
+    }
+
+    override suspend fun resolve(force: Boolean): BaseUrl? {
+        if (!force) cachedEndpoint?.let { return it }
+
+        val resolution = resolveMutex.withLock {
+            inFlight?.takeIf { it.isActive } ?: applicationScope.async {
+                try {
+                    performResolve(force)
+                } finally {
+                    resolveMutex.withLock { inFlight = null }
+                }
+            }.also { inFlight = it }
+        }
+        return resolution.await()
+    }
+
+    private suspend fun performResolve(force: Boolean): BaseUrl? {
+        val config = serverConfigRepository.observeServerConfig().first()
+        if (config == null) {
+            _state.value = ServerConnectionState.Unknown
+            return null
+        }
+        val expectedServerId = config.serverId
+
+        // The cached address is right almost always, so try it before spending 10s on a browse.
+        if (!force) {
+            val cachedUrl = serverConfigRepository.cachedServerUrl()
+            if (cachedUrl != null) {
+                // Stay Connected while re-verifying an address that is already known good. The
+                // health poll runs through here every 15s, and announcing Checking each time made
+                // the UI flash "server offline" between every successful probe.
+                if (_state.value !is ServerConnectionState.Connected) {
+                    _state.value = ServerConnectionState.Checking
+                }
+                when (val outcome = verify(cachedUrl, expectedServerId)) {
+                    is Verified.Ok -> return accept(cachedUrl)
+                    is Verified.WrongServer -> {
+                        // Do not fall through to the cache again; go looking for the real one.
+                        log.i { "Identity mismatch at $cachedUrl, re-resolving" }
+                    }
+                    is Verified.Unreachable -> log.i { "Cached address unreachable: ${outcome.reason}" }
+                }
+            }
+        }
+
+        // Without an identity there is nothing to search for — an unverifiable legacy pairing can
+        // only ever use the address it was given.
+        if (expectedServerId == null) {
+            _state.value = ServerConnectionState.Unreachable(NetworkFailure.Unreachable)
+            return null
+        }
+
+        // Throttle every browse, not just forced ones: the periodic health poll also lands here
+        // once the cached address stops answering, and mDNS browsing is not cheap.
+        if (!mayRebrowse()) {
+            log.i { "Skipping re-browse, throttled" }
+            _state.value = ServerConnectionState.Unreachable(NetworkFailure.Unreachable)
+            return null
+        }
+        lastForcedBrowse = TimeSource.Monotonic.markNow()
+
+        _state.value = ServerConnectionState.Resolving
+        val match = browseForServer(expectedServerId)
+        if (match == null) {
+            _state.value = ServerConnectionState.Unreachable(NetworkFailure.Unreachable)
+            return null
+        }
+
+        // A multi-homed server advertises several addresses; only some may be routable from here.
+        for (candidate in match.candidateUrls) {
+            val candidateUrl = BaseUrl(candidate)
+            if (verify(candidateUrl, expectedServerId) is Verified.Ok) {
+                log.i { "Server $expectedServerId resolved to $candidate" }
+                serverConfigRepository.updateCachedServerUrl(candidate)
+                return accept(candidateUrl)
+            }
+        }
+
+        _state.value = ServerConnectionState.Unreachable(NetworkFailure.Unreachable)
+        return null
+    }
+
+    private fun accept(baseUrl: BaseUrl): BaseUrl {
+        cachedEndpoint = baseUrl
+        _state.value = ServerConnectionState.Connected(baseUrl)
+        return baseUrl
+    }
+
+    private fun mayRebrowse(): Boolean {
+        val last = lastForcedBrowse ?: return true
+        return last.elapsedNow() >= MIN_REBROWSE_INTERVAL
+    }
+
+    private suspend fun browseForServer(expectedServerId: String): DiscoveredServer? =
+        withTimeoutOrNull(DISCOVERY_TIMEOUT) {
+            serverDiscoveryManager.discoverServers()
+                .first { servers -> servers.any { it.serverId == expectedServerId } }
+                .first { it.serverId == expectedServerId }
+        }
+
+    private suspend fun verify(baseUrl: BaseUrl, expectedServerId: String?): Verified =
+        when (val result = healthProbe.probe(baseUrl)) {
+            is ProbeResult.Healthy -> {
+                val actual = result.health.serverId
+                when {
+                    expectedServerId == null -> {
+                        // Pairing was made without an identity — manual entry, or against a server
+                        // that had no health endpoint. Adopt what it reports now, otherwise this
+                        // client could never find the server again once its address changed.
+                        log.i { "Adopting server identity $actual for an unidentified pairing" }
+                        serverConfigRepository.adoptServerId(actual)
+                        Verified.Ok
+                    }
+                    expectedServerId == actual -> Verified.Ok
+                    else -> {
+                        _state.value = ServerConnectionState.IdentityMismatch(
+                            expectedServerId = expectedServerId,
+                            actualServerId = actual
+                        )
+                        Verified.WrongServer
+                    }
+                }
+            }
+            is ProbeResult.Failed -> Verified.Unreachable(result.reason)
+        }
+
+    private sealed interface Verified {
+        data object Ok : Verified
+        data object WrongServer : Verified
+        data class Unreachable(val reason: NetworkFailure) : Verified
+    }
+}

--- a/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/ServerHealthProbe.kt
+++ b/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/ServerHealthProbe.kt
@@ -1,0 +1,51 @@
+package com.serratocreations.phovo.data.server
+
+import com.serratocreations.phovo.core.model.network.ApiEndpoints
+import com.serratocreations.phovo.core.model.network.BaseUrl
+import com.serratocreations.phovo.core.model.network.NetworkFailure
+import com.serratocreations.phovo.core.model.network.ServerHealth
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+
+/** Outcome of probing a candidate address. */
+sealed interface ProbeResult {
+    data class Healthy(val health: ServerHealth) : ProbeResult
+    data class Failed(val reason: NetworkFailure) : ProbeResult
+}
+
+/**
+ * Probes a Phovo server for liveness and identity.
+ *
+ * Deliberately given its own [HttpClient] rather than the shared application one, whose request
+ * timeout is measured in minutes because it carries photo uploads. A probe that takes minutes to
+ * fail is useless for deciding whether to go looking for the server somewhere else.
+ */
+class ServerHealthProbe(
+    private val client: HttpClient
+) {
+    suspend fun probe(baseUrl: BaseUrl): ProbeResult = try {
+        val response: HttpResponse = client.get(baseUrl / ApiEndpoints.HEALTH_API)
+        if (response.status.isSuccess()) {
+            ProbeResult.Healthy(response.body())
+        } else {
+            ProbeResult.Failed(NetworkFailure.HttpStatus)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        ProbeResult.Failed(classify(e))
+    }
+
+    private fun classify(e: Exception): NetworkFailure = when (e) {
+        is io.ktor.client.plugins.HttpRequestTimeoutException,
+        is io.ktor.client.network.sockets.ConnectTimeoutException,
+        is io.ktor.client.network.sockets.SocketTimeoutException -> NetworkFailure.Timeout
+        is kotlinx.serialization.SerializationException -> NetworkFailure.Malformed
+        is kotlinx.io.IOException -> NetworkFailure.Unreachable
+        else -> NetworkFailure.Unknown
+    }
+}

--- a/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/di/HealthProbeClient.kt
+++ b/data/server/src/commonIosAndroid/kotlin/com/serratocreations/phovo/data/server/di/HealthProbeClient.kt
@@ -1,0 +1,32 @@
+package com.serratocreations.phovo.data.server.di
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A client dedicated to health probes.
+ *
+ * Intentionally not the shared application client: that one allows minutes per request because it
+ * carries photo uploads, and a probe that takes minutes to fail cannot drive a decision about
+ * whether to go looking for the server elsewhere. Engine selection is left to the platform, which
+ * resolves to OkHttp on Android and Darwin on iOS.
+ */
+internal fun createHealthProbeClient(): HttpClient = HttpClient {
+    expectSuccess = false
+    install(ContentNegotiation) {
+        // Tolerate fields added by a newer server rather than failing the probe outright.
+        json(Json { ignoreUnknownKeys = true })
+    }
+    install(HttpTimeout) {
+        requestTimeoutMillis = PROBE_REQUEST_TIMEOUT.inWholeMilliseconds
+        connectTimeoutMillis = PROBE_CONNECT_TIMEOUT.inWholeMilliseconds
+        socketTimeoutMillis = PROBE_REQUEST_TIMEOUT.inWholeMilliseconds
+    }
+}
+
+private val PROBE_CONNECT_TIMEOUT = 2.seconds
+private val PROBE_REQUEST_TIMEOUT = 3.seconds

--- a/data/server/src/commonMain/kotlin/com/serratocreations/phovo/data/server/data/model/DiscoveredServer.kt
+++ b/data/server/src/commonMain/kotlin/com/serratocreations/phovo/data/server/data/model/DiscoveredServer.kt
@@ -3,7 +3,28 @@ package com.serratocreations.phovo.data.server.data.model
 data class DiscoveredServer(
     val name: String,
     val ipAddress: String,
-    val port: Int
+    val port: Int,
+    /**
+     * Identity advertised in the service's TXT record, or null if the record could not be read.
+     * Used to recognise a known server that has moved to a new address.
+     */
+    val serverId: String? = null,
+    val scheme: String = "http",
+    /**
+     * Every address the server advertised, most preferred first. [ipAddress] is the one that
+     * resolution produced; the rest are fallbacks for a multi-homed host.
+     */
+    val alternateAddresses: List<String> = emptyList()
 ) {
-    val url: String get() = "http://$ipAddress:$port"
+    val url: String get() = buildUrl(ipAddress)
+
+    /** Addresses to try in order, starting with the resolved one. */
+    val candidateUrls: List<String>
+        get() = (listOf(ipAddress) + alternateAddresses).distinct().map(::buildUrl)
+
+    private fun buildUrl(host: String): String {
+        // A bare IPv6 literal has to be bracketed before it can go in a URL authority.
+        val authority = if (host.contains(':') && !host.startsWith("[")) "[$host]" else host
+        return "$scheme://$authority:$port"
+    }
 }

--- a/data/server/src/iosMain/kotlin/com/serratocreations/phovo/data/server/IosServerDiscoveryManager.kt
+++ b/data/server/src/iosMain/kotlin/com/serratocreations/phovo/data/server/IosServerDiscoveryManager.kt
@@ -1,6 +1,7 @@
 package com.serratocreations.phovo.data.server
 
 import com.serratocreations.phovo.core.logger.PhovoLogger
+import com.serratocreations.phovo.core.model.network.ServerTxtRecord
 import com.serratocreations.phovo.core.serverconfig.ServerConfigRepository
 import com.serratocreations.phovo.data.server.data.model.DiscoveredServer
 import kotlinx.cinterop.ByteVar
@@ -25,6 +26,9 @@ import platform.Foundation.NSNetServiceBrowserDelegateProtocol
 import platform.Foundation.NSNetServiceDelegateProtocol
 import platform.Foundation.NSRunLoop
 import platform.Foundation.NSRunLoopCommonModes
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
 import platform.darwin.NSObject
 import platform.posix.getnameinfo
 import platform.posix.sockaddr
@@ -80,20 +84,7 @@ class IosServerDiscoveryManager(
                 val serviceDelegate = object : NSObject(), NSNetServiceDelegateProtocol {
                     override fun netServiceDidResolveAddress(sender: NSNetService) {
                         log.i { "netServiceDidResolveAddress: ${sender.name}" }
-                        val addresses = sender.addresses
-                        val ip = addresses?.firstNotNullOfOrNull { data ->
-                            val nsData = data as? NSData
-                            nsData?.let { ipAddressFromData(it) }
-                        } ?: sender.hostName ?: "localhost"
-
-                        val cleanedHost =
-                            if (ip.endsWith(".")) ip.substring(0, ip.length - 1) else ip
-
-                        val server = DiscoveredServer(
-                            name = sender.name,
-                            ipAddress = cleanedHost,
-                            port = sender.port.toInt()
-                        )
+                        val server = sender.toDiscoveredServer()
                         lock.lock()
                         try {
                             discoveredServers[sender.name] = server
@@ -170,7 +161,48 @@ class IosServerDiscoveryManager(
     override fun discoverServers(): Flow<List<DiscoveredServer>> = serverDiscoverySharedFlow
 
     override suspend fun connectToServer(server: DiscoveredServer) {
-        log.i { "Connecting to discovered server: ${server.url}" }
-        serverConfigRepository.updateClientServerConfig(server.url)
+        log.i { "Connecting to discovered server: ${server.url} id: ${server.serverId}" }
+        serverConfigRepository.updateClientServerConfig(
+            serverUrl = server.url,
+            serverId = server.serverId,
+            serviceName = server.name
+        )
+    }
+
+    private fun NSNetService.toDiscoveredServer(): DiscoveredServer {
+        // Prefer IPv4. The list is ordered by the resolver, not by usefulness, and an IPv6 literal
+        // needs bracketing before it can go in a URL — previously the first entry was taken as-is.
+        val resolvedAddresses = addresses
+            ?.mapNotNull { (it as? NSData)?.let(::ipAddressFromData) }
+            .orEmpty()
+            .map { it.removeSuffix(".") }
+        val host = resolvedAddresses.firstOrNull { !it.contains(':') }
+            ?: resolvedAddresses.firstOrNull()
+            ?: hostName?.removeSuffix(".")
+            ?: "localhost"
+
+        val advertisement = TXTRecordData()
+            ?.let { NSNetService.dictionaryFromTXTRecordData(it) }
+            ?.let { txtDictionary ->
+                val properties = txtDictionary.entries.associate { entry ->
+                    val key = entry.key as? String ?: ""
+                    val value = (entry.value as? NSData)?.let { data ->
+                        NSString.create(data, NSUTF8StringEncoding) as String?
+                    }
+                    key to value
+                }
+                ServerTxtRecord.decode(properties)
+            }
+
+        return DiscoveredServer(
+            name = name,
+            ipAddress = host,
+            port = port.toInt(),
+            serverId = advertisement?.serverId,
+            scheme = advertisement?.scheme ?: ServerTxtRecord.SCHEME_HTTP,
+            alternateAddresses = (advertisement?.addresses.orEmpty() + resolvedAddresses)
+                .distinct()
+                .filterNot { it == host }
+        )
     }
 }

--- a/data/server/src/iosMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.ios.kt
+++ b/data/server/src/iosMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.ios.kt
@@ -3,8 +3,11 @@ package com.serratocreations.phovo.data.server.di
 import com.serratocreations.phovo.core.common.di.MAIN_APPLICATION_SCOPE
 import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
 import com.serratocreations.phovo.core.serverconfig.ServerConfigRepository
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
 import com.serratocreations.phovo.data.server.IosServerDiscoveryManager
 import com.serratocreations.phovo.data.server.ServerDiscoveryManager
+import com.serratocreations.phovo.data.server.ServerEndpointResolverImpl
+import com.serratocreations.phovo.data.server.ServerHealthProbe
 import org.koin.core.module.Module
 import org.koin.dsl.binds
 import org.koin.dsl.module
@@ -17,6 +20,17 @@ internal actual fun getAndroidDesktopIosModules(): Module = module {
             get(),
             get(MAIN_APPLICATION_SCOPE),
             get()
+        )
+    }
+    single { ServerHealthProbe(createHealthProbeClient()) }
+    single<ServerEndpointResolver> {
+        ServerEndpointResolverImpl(
+            serverConfigRepository = get(),
+            serverDiscoveryManager = get(),
+            healthProbe = get(),
+            // Discovery is driven off the main run loop on iOS, so resolution shares that scope.
+            applicationScope = get(MAIN_APPLICATION_SCOPE),
+            logger = get()
         )
     }
 }

--- a/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/DesktopServerConfigManagerImpl.kt
+++ b/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/DesktopServerConfigManagerImpl.kt
@@ -9,6 +9,9 @@ import com.serratocreations.phovo.core.model.network.MediaItemDto
 import com.serratocreations.phovo.core.model.network.UploadInitResponse
 import com.serratocreations.phovo.data.photos.repository.LocalMediaRepository
 import com.serratocreations.phovo.core.model.ServerConfig
+import com.serratocreations.phovo.core.model.network.ApiEndpoints
+import com.serratocreations.phovo.core.model.network.ServerHealth
+import com.serratocreations.phovo.core.model.network.ServerTxtRecord
 import com.serratocreations.phovo.core.model.network.ApiEndpoints.GET_ALL_MEDIA_API
 import com.serratocreations.phovo.core.model.network.ApiEndpoints.HIGH_RES_THUMBNAIL_API
 import com.serratocreations.phovo.core.model.network.ApiEndpoints.LOW_RES_THUMBNAIL_API
@@ -25,6 +28,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.application.*
@@ -78,6 +82,38 @@ class DesktopServerConfigManagerImpl(
     private val log = logger.withTag("DesktopServerConfigManagerImpl")
     private var jmdns: JmDNS? = null
 
+    /**
+     * Held so the engine can be released before rebinding on reconfigure, and shut down cleanly on
+     * exit. Only touched from the ioDispatcher launch in [configureDeviceAsServer].
+     */
+    private var server: EmbeddedServer<*, *>? = null
+
+    private companion object {
+        const val SERVER_PORT = 8080
+        const val SERVER_STOP_GRACE_MILLIS = 1_000L
+        const val SERVER_STOP_TIMEOUT_MILLIS = 5_000L
+
+        // Only one instance is ever advertised, so the DNS-SD tie breakers are not meaningful.
+        const val SERVICE_WEIGHT = 0
+        const val SERVICE_PRIORITY = 0
+
+        /**
+         * Interface name prefixes used by hypervisors and container runtimes for host-only
+         * networks. Addresses on these are reachable from this machine only.
+         */
+        val HYPERVISOR_INTERFACE_PREFIXES = listOf(
+            "bridge",   // Parallels Desktop on macOS
+            "vmnet",    // VMware
+            "vboxnet",  // VirtualBox
+            "docker",   // Docker
+            "br-",      // Docker user defined bridges
+            "virbr",    // libvirt
+            "utun",     // macOS tunnels/VPNs
+            "tun",
+            "tap"
+        )
+    }
+
     init {
         Runtime.getRuntime().addShutdownHook(Thread {
             try {
@@ -86,23 +122,83 @@ class DesktopServerConfigManagerImpl(
             } catch (e: Exception) {
                 System.err.println("Error shutting down JmDNS: ${e.message}")
             }
+            try {
+                server?.stop(
+                    gracePeriodMillis = SERVER_STOP_GRACE_MILLIS,
+                    timeoutMillis = SERVER_STOP_TIMEOUT_MILLIS
+                )
+            } catch (e: Exception) {
+                System.err.println("Error shutting down Ktor server: ${e.message}")
+            }
         })
     }
 
+    /**
+     * Returns the IPv4 address clients on the LAN can actually reach this machine at.
+     *
+     * Interface enumeration order is not meaningful, and hypervisor bridges (Parallels, VMware,
+     * Docker, VirtualBox) hand out private addresses that look identical to a real LAN address
+     * while being reachable only from this host. [NetworkInterface.isVirtual] does not identify
+     * them — it only reports subinterfaces such as `en0:1`. Picking one of those silently
+     * configures every client with an unroutable server URL.
+     *
+     * The address the OS would use to leave this machine is the one clients share a network with,
+     * so that is preferred. Opening an unconnected UDP socket resolves the route without sending
+     * any packets. The interface scan is the fallback for when there is no default route, or when
+     * the route leaves through a tunnel that LAN clients are not on.
+     */
     private fun getHostIPv4(): String {
-        return try {
-            val interfaces = java.util.Collections.list(NetworkInterface.getNetworkInterfaces())
-            val candidates = interfaces
-                .filter { it.isUp && !it.isLoopback && !it.isVirtual }
-                .flatMap { ni -> java.util.Collections.list(ni.inetAddresses) }
-                .filterIsInstance<Inet4Address>()
-                .map { it.hostAddress }
-            candidates.firstOrNull { address ->
-                address.startsWith("192.") || address.startsWith("10.") || address.startsWith("172.")
-            } ?: candidates.firstOrNull() ?: "127.0.0.1"
-        } catch (e: Exception) {
-            "127.0.0.1"
+        val candidates = lanCandidateAddresses()
+        val defaultRouteAddress = defaultRouteIPv4()
+
+        log.i {
+            "Host IPv4 candidates: ${candidates.map { it.hostAddress }}, " +
+                "default route: ${defaultRouteAddress?.hostAddress}"
         }
+
+        // The routed address is authoritative when it also survived the interface scan.
+        if (defaultRouteAddress != null && defaultRouteAddress in candidates) {
+            return defaultRouteAddress.hostAddress
+        }
+
+        // Otherwise the route leaves through an excluded interface — a VPN tunnel, say — so fall
+        // back to a private address a client on the same LAN can route to.
+        return candidates.firstOrNull { it.isSiteLocalAddress }?.hostAddress
+            ?: defaultRouteAddress?.hostAddress
+            ?: candidates.firstOrNull()?.hostAddress
+            ?: "127.0.0.1"
+    }
+
+    private fun defaultRouteIPv4(): Inet4Address? = try {
+        java.net.DatagramSocket().use { socket ->
+            // Connecting a UDP socket only selects a route, no traffic is sent.
+            socket.connect(InetAddress.getByName("1.1.1.1"), 53)
+            (socket.localAddress as? Inet4Address)?.takeIf { it.isUsableHostAddress() }
+        }
+    } catch (e: Exception) {
+        log.e(e) { "Unable to resolve default route address" }
+        null
+    }
+
+    private fun lanCandidateAddresses(): List<Inet4Address> = try {
+        java.util.Collections.list(NetworkInterface.getNetworkInterfaces())
+            .filter { it.isUp && !it.isLoopback && !it.isVirtual && !it.isPointToPoint && it.supportsMulticast() }
+            .filterNot { it.name.isHypervisorInterfaceName() }
+            .flatMap { ni -> java.util.Collections.list(ni.inetAddresses) }
+            .filterIsInstance<Inet4Address>()
+            .filter { it.isUsableHostAddress() }
+    } catch (e: Exception) {
+        log.e(e) { "Unable to enumerate network interfaces" }
+        emptyList()
+    }
+
+    /** Excludes the wildcard, loopback and self-assigned (169.254.0.0/16) addresses. */
+    private fun Inet4Address.isUsableHostAddress(): Boolean =
+        !isAnyLocalAddress && !isLoopbackAddress && !isLinkLocalAddress
+
+    private fun String.isHypervisorInterfaceName(): Boolean {
+        val name = lowercase()
+        return HYPERVISOR_INTERFACE_PREFIXES.any { name.startsWith(it) }
     }
 
     override fun getDefaultServerName(): String {
@@ -136,6 +232,21 @@ class DesktopServerConfigManagerImpl(
             get("/") {
                 serverEventsRepository.addServerEventLog("get ${LocalDateTime.now()}")
                 call.respond(HttpStatusCode.OK, "Phovo server is running")
+            }
+
+            // Liveness plus identity. Clients use serverId to confirm they are still talking to
+            // the server they paired with, rather than to whoever now holds that address.
+            get("/${ApiEndpoints.HEALTH_API.value}") {
+                val config = serverConfigRepository.observeServerConfig().first()
+                val serverId = serverConfigRepository.serverId()
+                if (config == null || serverId == null) {
+                    call.respond(HttpStatusCode.ServiceUnavailable, "Server is not configured")
+                    return@get
+                }
+                call.respond(
+                    HttpStatusCode.OK,
+                    ServerHealth(serverId = serverId, serverName = config.serverName)
+                )
             }
 
             get("/${GET_ALL_MEDIA_API.value}") {
@@ -323,31 +434,78 @@ class DesktopServerConfigManagerImpl(
                 }
                 jmdns = null
 
-                embeddedServer(factory = Netty, port = 8080, host = "0.0.0.0", module = routingConfig)
-                    .start(wait = false)
+                // Reconfiguring is a supported action (this is called from both DesktopAppInitializer
+                // on startup and the connections UI), so the previous engine has to be released
+                // before rebinding the port — otherwise the second call fails with a BindException.
+                try {
+                    server?.stop(
+                        gracePeriodMillis = SERVER_STOP_GRACE_MILLIS,
+                        timeoutMillis = SERVER_STOP_TIMEOUT_MILLIS
+                    )
+                } catch (e: Exception) {
+                    log.e(e) { "Error stopping existing Ktor server" }
+                }
+                server = null
+
+                server = try {
+                    embeddedServer(
+                        factory = Netty,
+                        port = SERVER_PORT,
+                        host = "0.0.0.0",
+                        module = routingConfig
+                    ).also { it.start(wait = false) }
+                } catch (e: Exception) {
+                    log.e(e) { "Failed to start Ktor server on port $SERVER_PORT" }
+                    serverConfigState.update { it.copy(configStatus = ConfigStatus.NotConfigured) }
+                    return@launch
+                }
 
                 val hostIp = getHostIPv4()
-                log.i { "Starting JmDNS advertisement for server IP: $hostIp" }
+                // Written by updateServerConfig above, so this is only null if that failed.
+                val serverId = serverConfigRepository.serverId()
+                if (serverId == null) {
+                    log.e { "Server id missing after configuration, skipping mDNS advertisement" }
+                    serverConfigState.update {
+                        it.copy(configStatus = ConfigStatus.Configured("http://$hostIp:$SERVER_PORT"))
+                    }
+                    return@launch
+                }
+                log.i { "Starting JmDNS advertisement for server IP: $hostIp id: $serverId" }
                 try {
                     val inetAddress = InetAddress.getByName(hostIp)
                     val sanitizedName = serverConfig.serverName.replace(".", " ")
+                    // Advertise every address this host believes it is reachable on, with the
+                    // routable one first, so a client that cannot reach the primary has somewhere
+                    // else to try. A single JmDNS instance is used deliberately: one instance per
+                    // interface makes jmdns rename the service ("name (2)"), and both clients key
+                    // their discovery map on the service name.
+                    val advertisedAddresses = (listOf(hostIp) + lanCandidateAddresses()
+                        .map { it.hostAddress })
+                        .distinct()
+                    val txtRecord = ServerTxtRecord.encode(
+                        serverId = serverId,
+                        serverName = sanitizedName,
+                        addresses = advertisedAddresses
+                    )
                     jmdns = JmDNS.create(inetAddress, "PhovoServer").apply {
                         val serviceInfo = ServiceInfo.create(
                             "_phovo._tcp.local.",
                             sanitizedName,
-                            8080,
-                            "Phovo Photo Backup Server"
+                            SERVER_PORT,
+                            SERVICE_WEIGHT,
+                            SERVICE_PRIORITY,
+                            txtRecord
                         )
                         registerService(serviceInfo)
                     }
-                    log.i { "JmDNS service registered successfully" }
+                    log.i { "JmDNS service registered successfully with TXT $txtRecord" }
                 } catch (e: Exception) {
                     log.e(e) { "Failed to start JmDNS service advertising" }
                 }
 
                 serverConfigState.update {
                     it.copy(configStatus = ConfigStatus.Configured(
-                        serverUrl = "http://$hostIp:8080"
+                        serverUrl = "http://$hostIp:$SERVER_PORT"
                     ))
                 }
             }

--- a/docs/server-discovery-refactor.html
+++ b/docs/server-discovery-refactor.html
@@ -1,0 +1,358 @@
+<title>Server Discovery Refactor</title>
+<style>
+  :root {
+    --bg: #F4F7F5;
+    --surface: #FFFFFF;
+    --surface-2: #EDF2EF;
+    --border: #D5E0DA;
+    --text: #10201B;
+    --text-muted: #5A6B64;
+    --accent: #0B7A5E;
+    --accent-soft: #E1F1EA;
+    --danger: #B3372A;
+    --danger-soft: #F7E5E2;
+    --shadow: 0 1px 2px rgba(16, 32, 27, .06), 0 8px 24px rgba(16, 32, 27, .05);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #0C1512;
+      --surface: #131F1B;
+      --surface-2: #182823;
+      --border: #26372F;
+      --text: #E8F0EC;
+      --text-muted: #94A89F;
+      --accent: #3FD3A3;
+      --accent-soft: #133129;
+      --danger: #F08375;
+      --danger-soft: #33201D;
+      --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .3);
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #0C1512;
+    --surface: #131F1B;
+    --surface-2: #182823;
+    --border: #26372F;
+    --text: #E8F0EC;
+    --text-muted: #94A89F;
+    --accent: #3FD3A3;
+    --accent-soft: #133129;
+    --danger: #F08375;
+    --danger-soft: #33201D;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 8px 24px rgba(0, 0, 0, .3);
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    margin: 0;
+    padding: 56px 24px 96px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 1000px; margin: 0 auto; display: flex; flex-direction: column; gap: 44px; }
+  .measure { max-width: 68ch; }
+
+  h1, h2, h3 {
+    font-family: ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    text-wrap: balance;
+    margin: 0;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  h1 { font-size: clamp(2rem, 4.5vw, 2.9rem); line-height: 1.12; }
+  h2 { font-size: 1.5rem; line-height: 1.25; }
+  h3 { font-size: 1.06rem; }
+  p { margin: 0; }
+  code, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace; font-size: .88em; }
+  code { background: var(--surface-2); padding: .1em .36em; border-radius: 4px; }
+  a { color: var(--accent); }
+
+  .eyebrow {
+    font-size: .74rem; text-transform: uppercase; letter-spacing: .13em;
+    color: var(--text-muted); font-weight: 600;
+  }
+  .lede { font-size: 1.13rem; color: var(--text-muted); }
+
+  header { display: flex; flex-direction: column; gap: 14px; }
+
+  .stats {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
+    gap: 1px; background: var(--border); border: 1px solid var(--border);
+    border-radius: 10px; overflow: hidden;
+  }
+  .stat { background: var(--surface); padding: 14px 16px; display: flex; flex-direction: column; gap: 2px; }
+  .stat .n {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 1.4rem; font-variant-numeric: tabular-nums; letter-spacing: -.02em;
+  }
+  .stat .k { font-size: .74rem; text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); }
+  .add { color: var(--accent); }
+  .del { color: var(--danger); }
+
+  section { display: flex; flex-direction: column; gap: 16px; }
+
+  figure {
+    margin: 0; background: var(--surface); border: 1px solid var(--border);
+    border-radius: 12px; padding: 22px 20px 16px; box-shadow: var(--shadow);
+    overflow-x: auto;
+  }
+  figure svg { display: block; width: 100%; min-width: 640px; height: auto; }
+  figcaption { margin-top: 14px; font-size: .87rem; color: var(--text-muted); }
+
+  .phase {
+    display: grid; grid-template-columns: 2.1rem 1fr; gap: 4px 14px;
+    padding: 18px 20px; background: var(--surface);
+    border: 1px solid var(--border); border-radius: 10px;
+  }
+  .phase .num {
+    grid-row: span 2;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: .95rem; color: var(--accent); font-variant-numeric: tabular-nums;
+    padding-top: .16rem;
+  }
+  .phase p { color: var(--text-muted); font-size: .95rem; }
+  .phases { display: flex; flex-direction: column; gap: 10px; }
+
+  .note {
+    border: 1px solid var(--border); background: var(--surface);
+    border-radius: 8px; padding: 16px 18px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .note p { font-size: .95rem; color: var(--text-muted); }
+
+  table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); }
+  th { font-size: .72rem; text-transform: uppercase; letter-spacing: .09em; color: var(--text-muted); font-weight: 600; }
+  td.num { text-align: right; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
+  .tablewrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+  tbody tr:last-child td { border-bottom: none; }
+
+  ul { margin: 0; padding-left: 1.15rem; display: flex; flex-direction: column; gap: 7px; }
+  li { color: var(--text-muted); font-size: .95rem; }
+  li strong { color: var(--text); font-weight: 600; }
+</style>
+
+<div class="wrap">
+
+  <header>
+    <span class="eyebrow">Phovo &middot; working tree, uncommitted</span>
+    <h1>Persist who the server is, resolve where it is</h1>
+    <p class="lede measure">Issue #133 was filed as an Android permission bug. It wasn&rsquo;t &mdash; the grant was present the whole time. The real fault was #131: the desktop advertised a Parallels host-only address, and the client stored that unroutable URL as the permanent identity of the connection.</p>
+  </header>
+
+  <div class="stats">
+    <div class="stat"><span class="n">43</span><span class="k">files</span></div>
+    <div class="stat"><span class="n add">+1245</span><span class="k">insertions</span></div>
+    <div class="stat"><span class="n del">&minus;165</span><span class="k">deletions</span></div>
+    <div class="stat"><span class="n">8</span><span class="k">new files</span></div>
+    <div class="stat"><span class="n">3</span><span class="k">platforms</span></div>
+    <div class="stat"><span class="n">6</span><span class="k">issues filed</span></div>
+  </div>
+
+  <section>
+    <h2>What actually changed</h2>
+    <p class="measure">An IP address is a DHCP lease, not an identity. Storing one as the connection&rsquo;s primary key meant any address change bricked the client with no recovery path &mdash; discovery couldn&rsquo;t help, because the client stops browsing the moment a config row exists.</p>
+
+    <figure>
+      <svg viewBox="0 0 860 430" role="img" aria-label="Before, the client stored an IP address as the server's identity and an address change was a dead end. After, the client stores a stable server id and re-resolves the address when a probe fails.">
+        <defs>
+          <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+          </marker>
+          <marker id="ar-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"/>
+          </marker>
+          <marker id="ar-d" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--danger)"/>
+          </marker>
+        </defs>
+
+        <text x="0" y="18" font-size="12" font-weight="700" fill="currentColor" letter-spacing="1.4">BEFORE</text>
+        <line x1="72" y1="13" x2="860" y2="13" stroke="currentColor" stroke-opacity=".18"/>
+
+        <rect x="0" y="46" width="168" height="58" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="84" y="72" font-size="13" text-anchor="middle" fill="currentColor">Desktop server</text>
+        <text x="84" y="90" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">picks one address</text>
+
+        <line x1="168" y1="75" x2="286" y2="75" stroke="currentColor" stroke-opacity=".5" marker-end="url(#ar)"/>
+        <text x="227" y="66" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".65">advertises</text>
+
+        <rect x="292" y="46" width="230" height="58" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="407" y="70" font-size="13" text-anchor="middle" fill="currentColor">Client database</text>
+        <text x="407" y="89" font-size="11.5" text-anchor="middle" fill="currentColor" fill-opacity=".75" font-family="ui-monospace, Menlo, monospace">http://10.37.129.2:8080</text>
+
+        <line x1="522" y1="75" x2="660" y2="75" stroke="var(--danger)" marker-end="url(#ar-d)"/>
+        <text x="591" y="66" font-size="11" text-anchor="middle" fill="var(--danger)">address changes</text>
+
+        <rect x="666" y="46" width="194" height="58" rx="7" fill="none" stroke="var(--danger)"/>
+        <text x="763" y="70" font-size="13" text-anchor="middle" fill="var(--danger)">Dead end</text>
+        <text x="763" y="89" font-size="11" text-anchor="middle" fill="var(--danger)" fill-opacity=".8">user must re-pair</text>
+
+        <text x="0" y="182" font-size="12" font-weight="700" fill="var(--accent)" letter-spacing="1.4">AFTER</text>
+        <line x1="62" y1="177" x2="860" y2="177" stroke="var(--accent)" stroke-opacity=".3"/>
+
+        <rect x="0" y="212" width="168" height="58" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="84" y="236" font-size="13" text-anchor="middle" fill="currentColor">Desktop server</text>
+        <text x="84" y="255" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">stable serverId</text>
+
+        <line x1="168" y1="241" x2="286" y2="241" stroke="currentColor" stroke-opacity=".5" marker-end="url(#ar)"/>
+        <text x="227" y="226" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".65">mDNS TXT:</text>
+        <text x="227" y="238" font-size="10.5" text-anchor="middle" fill="currentColor" fill-opacity=".65" font-family="ui-monospace, Menlo, monospace">id, addrs</text>
+
+        <rect x="292" y="212" width="230" height="58" rx="7" fill="var(--accent-soft)" stroke="var(--accent)"/>
+        <text x="407" y="236" font-size="13" text-anchor="middle" fill="currentColor">Client database</text>
+        <text x="407" y="255" font-size="11.5" text-anchor="middle" fill="currentColor" fill-opacity=".75" font-family="ui-monospace, Menlo, monospace">serverId (identity)</text>
+
+        <line x1="522" y1="241" x2="660" y2="241" stroke="var(--accent)" marker-end="url(#ar-a)"/>
+        <text x="591" y="232" font-size="11" text-anchor="middle" fill="var(--accent)">resolves to</text>
+
+        <rect x="666" y="212" width="194" height="58" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="763" y="236" font-size="13" text-anchor="middle" fill="currentColor">Address in use</text>
+        <text x="763" y="255" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">a cache, not a key</text>
+
+        <path d="M 763 270 L 763 348 Q 763 362 749 362 L 421 362 Q 407 362 407 348 L 407 272"
+              fill="none" stroke="var(--accent)" stroke-dasharray="5 4" marker-end="url(#ar-a)"/>
+        <text x="585" y="381" font-size="11.5" text-anchor="middle" fill="var(--accent)">probe fails &rarr; re-browse by id &rarr; write new address</text>
+        <text x="585" y="399" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".55">no user action required</text>
+      </svg>
+      <figcaption>The address moved from being the connection&rsquo;s identity to being a cache of it. That single change is what makes the dashed recovery path possible.</figcaption>
+    </figure>
+  </section>
+
+  <section>
+    <h2>How resolution works</h2>
+    <p class="measure">The cached address is tried first because it is almost always right. Identity is what makes the failure case recoverable, and what stops the client uploading to a stranger&rsquo;s machine after a DHCP reshuffle.</p>
+
+    <figure>
+      <svg viewBox="0 0 860 330" role="img" aria-label="Resolution starts from the cached address and probes the health endpoint. A matching identity means connected; a different identity means identity mismatch and uploads are blocked; no answer triggers an mDNS browse for the server id, which either verifies and updates the cache or reports unreachable.">
+        <defs>
+          <marker id="br" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+          </marker>
+          <marker id="br-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"/>
+          </marker>
+          <marker id="br-d" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--danger)"/>
+          </marker>
+        </defs>
+        <rect x="0" y="128" width="150" height="54" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="75" y="150" font-size="12.5" text-anchor="middle" fill="currentColor">Cached address</text>
+        <text x="75" y="168" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">fast path</text>
+
+        <line x1="150" y1="155" x2="212" y2="155" stroke="currentColor" stroke-opacity=".5" marker-end="url(#br)"/>
+
+        <rect x="218" y="128" width="146" height="54" rx="7" fill="var(--surface-2)" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="291" y="150" font-size="12.5" text-anchor="middle" fill="currentColor" font-family="ui-monospace, Menlo, monospace">GET /health</text>
+        <text x="291" y="168" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">2s timeout</text>
+
+        <path d="M 364 143 Q 470 143 470 74 L 646 74" fill="none" stroke="var(--accent)" marker-end="url(#br-a)"/>
+        <text x="556" y="64" font-size="11" text-anchor="middle" fill="var(--accent)">id matches</text>
+
+        <rect x="652" y="48" width="208" height="52" rx="7" fill="var(--accent-soft)" stroke="var(--accent)"/>
+        <text x="756" y="79" font-size="12.5" text-anchor="middle" fill="currentColor">Connected</text>
+
+        <line x1="364" y1="155" x2="646" y2="155" stroke="var(--danger)" marker-end="url(#br-d)"/>
+        <text x="505" y="146" font-size="11" text-anchor="middle" fill="var(--danger)">different server answered</text>
+
+        <rect x="652" y="129" width="208" height="52" rx="7" fill="var(--danger-soft)" stroke="var(--danger)"/>
+        <text x="756" y="150" font-size="12.5" text-anchor="middle" fill="var(--danger)">Identity mismatch</text>
+        <text x="756" y="168" font-size="11" text-anchor="middle" fill="var(--danger)" fill-opacity=".85">uploads blocked, polling stops</text>
+
+        <path d="M 291 182 L 291 250 L 374 250" fill="none" stroke="currentColor" stroke-opacity=".5" marker-end="url(#br)"/>
+        <text x="300" y="222" font-size="11" fill="currentColor" fill-opacity=".65">no answer</text>
+
+        <rect x="380" y="224" width="180" height="54" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="470" y="246" font-size="12.5" text-anchor="middle" fill="currentColor">Browse mDNS by id</text>
+        <text x="470" y="264" font-size="11" text-anchor="middle" fill="currentColor" fill-opacity=".6">10s window, 30s throttle</text>
+
+        <path d="M 560 240 Q 610 240 610 105 L 610 100" fill="none" stroke="var(--accent)" marker-end="url(#br-a)"/>
+        <path d="M 610 100 L 646 100" fill="none" stroke="var(--accent)" marker-end="url(#br-a)"/>
+        <text x="628" y="200" font-size="11" text-anchor="middle" fill="var(--accent)" transform="rotate(-90 628 200)">found &rarr; verify &rarr; cache updated</text>
+
+        <line x1="560" y1="266" x2="646" y2="266" stroke="currentColor" stroke-opacity=".5" marker-end="url(#br)"/>
+        <rect x="652" y="240" width="208" height="52" rx="7" fill="none" stroke="currentColor" stroke-opacity=".45"/>
+        <text x="756" y="271" font-size="12.5" text-anchor="middle" fill="currentColor">Unreachable</text>
+      </svg>
+      <figcaption>Every caller shares one in-flight resolution, so six sync workers failing together trigger one browse rather than six.</figcaption>
+    </figure>
+  </section>
+
+  <section>
+    <h2>Delivered in three dependent phases</h2>
+    <div class="phases">
+      <div class="phase">
+        <span class="num">01</span>
+        <h3>A connection state that can express uncertainty</h3>
+        <p><code>ServerConnectionState</code> replaces a bare boolean with Unknown, Checking, Resolving, Connected, Unreachable and IdentityMismatch. A boolean shim keeps every existing caller&rsquo;s semantics unchanged. Side effect: an unconfigured client no longer shows a red status dot for a problem it doesn&rsquo;t have.</p>
+      </div>
+      <div class="phase">
+        <span class="num">02</span>
+        <h3>The server publishes an identity</h3>
+        <p>A UUID minted once and preserved across reconfiguration, served from <code>GET /health</code> and advertised in structured mDNS TXT records (<code>id</code>, <code>v</code>, <code>name</code>, <code>scheme</code>, <code>addrs</code>). Keys and codec live in shared code so the two ends can&rsquo;t drift. A newer client falls back to the old liveness route on a 404, so a phone updated ahead of its desktop still connects.</p>
+      </div>
+      <div class="phase">
+        <span class="num">03</span>
+        <h3>The client resolves by identity</h3>
+        <p>Config now carries identity only, so re-resolving no longer restarts the health poll or blanks the photo feed. Both discovery implementations read TXT records; iOS additionally gained IPv4 preference and IPv6 bracketing, which it never had.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Two defects found while reviewing my own work</h2>
+    <ul class="measure">
+      <li><strong>Identity could be minted twice.</strong> <code>getOrCreateServerId()</code> generated a UUID but never persisted it, so the name lied and any caller before configuration would get a different id each time. Minting now happens in exactly one place.</li>
+      <li><strong>Manual pairings could never recover.</strong> A typed-in address stores no identity, and the resolver bailed straight to Unreachable &mdash; making the most common pairing path the one that could never self-heal. The client now adopts the identity the server reports on first successful probe, guarded in SQL so it can never repoint an already-identified client.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sync is untouched</h2>
+    <div class="note">
+      <p>An earlier attempt to bound three unbounded waits broke sync on Android and was fully reverted. The wait in <code>LocalMediaManager</code> turned out to be load-bearing: it is how a client launched before it has a server starts syncing once one is connected. Bounding it meant connecting afterwards did nothing.</p>
+      <p>Those files are now byte-identical to <code>HEAD</code> apart from one two-line delegating override that the interface change requires. The concerns are recorded in <strong>#139</strong>, including that constraint, so the same wrong fix isn&rsquo;t attempted again.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Where the code moved</h2>
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr><th>Module</th><th>Role in the refactor</th><th class="num">Files</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="mono">data/server</td><td>Advertisement, discovery, endpoint resolver</td><td class="num">10</td></tr>
+          <tr><td class="mono">core/model</td><td>Shared protocol: state, health, TXT codec, URL rules</td><td class="num">7</td></tr>
+          <tr><td class="mono">data/photos</td><td>Connection state plumbing, error classification</td><td class="num">6</td></tr>
+          <tr><td class="mono">core/serverconfig</td><td>Identity persistence, resolver contract</td><td class="num">5</td></tr>
+          <tr><td class="mono">core/domain</td><td>Backup status carries a failure reason</td><td class="num">4</td></tr>
+          <tr><td class="mono">core/database</td><td>Identity columns and schema</td><td class="num">4</td></tr>
+          <tr><td class="mono">feature/photos</td><td>Offline state carries a reason</td><td class="num">4</td></tr>
+          <tr><td class="mono">feature/connections</td><td>Manual entry validation, live connection state</td><td class="num">1</td></tr>
+          <tr><td class="mono">sharedumbrella</td><td>Status dot distinguishes unknown from down</td><td class="num">1</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="measure" style="font-size:.92rem;color:var(--text-muted)">Compiles clean on Android, desktop JVM and iOS simulator; <code>:androidApp:assembleDebug</code> builds. Nothing has been run &mdash; end-to-end verification is yours.</p>
+  </section>
+
+  <section>
+    <h2>Issues filed</h2>
+    <ul class="measure">
+      <li><strong>#134</strong> &mdash; No authentication or transport security, plus an unauthenticated path traversal in the chunk upload route</li>
+      <li><strong>#135</strong> &mdash; Server identity stored only in the desktop database</li>
+      <li><strong>#136</strong> &mdash; Address and port mutability follow-ups</li>
+      <li><strong>#137</strong> &mdash; Coil never registers a Ktor network fetcher</li>
+      <li><strong>#138</strong> &mdash; No automated test coverage</li>
+      <li><strong>#139</strong> &mdash; Sync stalls on connection loss instead of ending the pass</li>
+    </ul>
+  </section>
+
+</div>

--- a/feature/connections/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/connections/ui/ClientConnectionsViewModel.kt
+++ b/feature/connections/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/connections/ui/ClientConnectionsViewModel.kt
@@ -1,7 +1,10 @@
 package com.serratocreations.phovo.feature.connections.ui
 
 import androidx.lifecycle.viewModelScope
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
+import com.serratocreations.phovo.core.model.network.normalizeServerUrl
 import com.serratocreations.phovo.core.serverconfig.IosAndroidServerConfigRepository
+import com.serratocreations.phovo.core.serverconfig.ServerEndpointResolver
 import com.serratocreations.phovo.data.permissions.PermissionRepository
 import com.serratocreations.phovo.data.permissions.PermissionStatus
 import com.serratocreations.phovo.data.server.ServerDiscoveryManager
@@ -17,6 +20,7 @@ import kotlinx.coroutines.launch
 class ClientConnectionsViewModel(
     private val serverConfigRepository: IosAndroidServerConfigRepository,
     private val serverDiscoveryManager: ServerDiscoveryManager,
+    private val endpointResolver: ServerEndpointResolver,
     private val permissionRepository: PermissionRepository
 ): ConnectionsViewModel(
     serverConfigRepository = serverConfigRepository
@@ -29,6 +33,7 @@ class ClientConnectionsViewModel(
 
     init {
         observeClientConfigState()
+        observeConnectionState()
         observePermissionStatus()
     }
 
@@ -36,17 +41,31 @@ class ClientConnectionsViewModel(
         serverConfigRepository.observeServerConfig()
             .onEach { serverConfig ->
                 val isConfigured = serverConfig != null
-                val serverUrl = serverConfig?.serverBaseUrlString?.value
 
                 _connectionsUiState.update {
-                    it.copy(
-                        isClientConfigured = isConfigured,
-                        configuredServerUrl = serverUrl
-                    )
+                    it.copy(isClientConfigured = isConfigured)
                 }
 
                 if (isConfigured) {
                     stopDiscovery()
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    /**
+     * The config only records which server we are paired with, so the address shown to the user
+     * comes from the resolver — that is the one actually in use, and it survives the server moving.
+     */
+    private fun observeConnectionState() {
+        endpointResolver.state
+            .onEach { connectionState ->
+                _connectionsUiState.update {
+                    it.copy(
+                        connectionState = connectionState,
+                        configuredServerUrl =
+                            (connectionState as? ServerConnectionState.Connected)?.baseUrl?.value
+                    )
                 }
             }
             .launchIn(viewModelScope)
@@ -112,9 +131,22 @@ class ClientConnectionsViewModel(
         }
     }
 
+    /**
+     * Pairs with a manually entered address. The address is normalised first — it is free text, and
+     * a missing scheme or a trailing slash would otherwise surface later as an unexplained
+     * "server unreachable". Identity is left null here; the resolver adopts whatever the server
+     * reports on the first successful health probe.
+     */
     fun connectManually(url: String) {
         viewModelScope.launch {
-            serverConfigRepository.updateClientServerConfig(url)
+            val normalizedUrl = normalizeServerUrl(url)
+            if (normalizedUrl == null) {
+                _connectionsUiState.update { it.copy(manualUrlError = true) }
+                return@launch
+            }
+            _connectionsUiState.update { it.copy(manualUrlError = false) }
+            serverConfigRepository.updateClientServerConfig(serverUrl = normalizedUrl)
+            endpointResolver.invalidate()
         }
     }
 
@@ -131,5 +163,8 @@ data class ClientConnectionsUiState(
     val isSearching: Boolean = false,
     val discoveredServers: List<DiscoveredServer> = emptyList(),
     val localNetworkPermissionStatus: PermissionStatus = PermissionStatus.Ungranted,
-    val isManualUrlExpanded: Boolean = false
+    val isManualUrlExpanded: Boolean = false,
+    /** Live connection status. Distinct from [isClientConfigured], which only means a pairing exists. */
+    val connectionState: ServerConnectionState = ServerConnectionState.Unknown,
+    val manualUrlError: Boolean = false
 ): ConnectionsUiState

--- a/feature/photos/build.gradle.kts
+++ b/feature/photos/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             implementation(projects.core.designsystem)
             implementation(projects.core.common)
             implementation(projects.core.logger)
+            implementation(projects.core.model)
             implementation(projects.data.photos)
             implementation(projects.data.server)
             implementation(projects.core.navigation)

--- a/feature/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/photos/ui/BackupStatusViewModel.kt
+++ b/feature/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/photos/ui/BackupStatusViewModel.kt
@@ -49,6 +49,6 @@ fun BackupStatus.toBackupStatus(
             totalCount = this.totalSyncJobQuantity
         )
         BackupStatus.Scanning -> PreparingBackupUiModel
-        BackupStatus.ServerOffline -> ServerOfflineUiModel
+        is BackupStatus.ServerOffline -> ServerOfflineUiModel(reason = this.reason)
     }
 }

--- a/feature/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/photos/ui/components/ExpandableBackupBanner.kt
+++ b/feature/photos/src/commonIosAndroid/kotlin/com/serratocreations/phovo/feature/photos/ui/components/ExpandableBackupBanner.kt
@@ -120,7 +120,7 @@ fun ExpandableBackupBanner(
                             trackStroke = thinStroke
                         )
                     }
-                    ServerOfflineUiModel -> {
+                    is ServerOfflineUiModel -> {
                         Icon(
                             painter = painterResource(Res.drawable.ic_cloud_off_outlined),
                             contentDescription = stringResource(backupState.chipText),
@@ -242,7 +242,7 @@ fun BackupSummaryCard(
                             modifier = Modifier.size(defaultIconSize)
                         )
                     }
-                    ServerOfflineUiModel -> {
+                    is ServerOfflineUiModel -> {
                         Icon(
                             painter = painterResource(Res.drawable.ic_cloud_off_outlined),
                             contentDescription = stringResource(status.chipText),

--- a/feature/photos/src/commonMain/kotlin/com/serratocreations/phovo/feature/photos/ui/model/BackupStatusUiModel.kt
+++ b/feature/photos/src/commonMain/kotlin/com/serratocreations/phovo/feature/photos/ui/model/BackupStatusUiModel.kt
@@ -4,6 +4,7 @@ import com.serratocreations.phovo.core.common.util.localize
 import com.serratocreations.phovo.core.designsystem.PhovoPlural
 import com.serratocreations.phovo.core.designsystem.PhovoString
 import com.serratocreations.phovo.core.designsystem.UiStringBuilder
+import com.serratocreations.phovo.core.model.network.NetworkFailure
 import org.jetbrains.compose.resources.StringResource
 import phovo.feature.photos.generated.resources.Res
 import phovo.feature.photos.generated.resources.chip_backup_complete
@@ -38,7 +39,15 @@ sealed interface BackupStatusUiModel {
     val actionButton: BackupActionButton?
 }
 
-data object ServerOfflineUiModel: BackupStatusUiModel {
+/**
+ * @param reason why the server is unreachable, or null when no server is configured yet. Carried so
+ * the copy can be specialised per failure without another change to this hierarchy; the strings are
+ * still generic today.
+ */
+data class ServerOfflineUiModel(
+    val reason: NetworkFailure? = null,
+    override val actionButton: BackupActionButton? = null
+): BackupStatusUiModel {
     override val chipText: StringResource = Res.string.chip_server_offline
     override val header: UiStringBuilder = UiStringBuilder(
         PhovoString(Res.string.header_server_offline))
@@ -46,7 +55,6 @@ data object ServerOfflineUiModel: BackupStatusUiModel {
         PhovoString(Res.string.main_status_server_offline))
     override val statusDescription: UiStringBuilder = UiStringBuilder(
         PhovoString(Res.string.description_server_offline))
-    override val actionButton: BackupActionButton? = null
 }
 
 data object PreparingBackupUiModel: BackupStatusUiModel {

--- a/sharedumbrella/src/commonMain/kotlin/com/serratocreations/phovo/ui/viewmodel/ApplicationViewModel.kt
+++ b/sharedumbrella/src/commonMain/kotlin/com/serratocreations/phovo/ui/viewmodel/ApplicationViewModel.kt
@@ -2,6 +2,7 @@ package com.serratocreations.phovo.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.serratocreations.phovo.core.model.network.ServerConnectionState
 import com.serratocreations.phovo.data.photos.repository.MediaRepository
 import com.serratocreations.phovo.data.photos.repository.RemoteMediaRepository
 import com.serratocreations.phovo.ui.model.OverflowMenuOption
@@ -26,21 +27,27 @@ class ApplicationViewModel(
         viewModelScope.observeServerStatus()
     }
 
-    private fun CoroutineScope.observeServerStatus() = launch {
-        if(mediaRepository is RemoteMediaRepository) {
-            mediaRepository.observeServerConnection()
-                .onEach { isServerConnectionSuccess ->
-                    _applicationUiState.update { uiState ->
-                        uiState.copy(serverStatusColor = if (isServerConnectionSuccess) {
-                                ServerStatusColor.Green
-                            } else {
-                                ServerStatusColor.Red
-                            }
-                        )
-                    }
+    private fun CoroutineScope.observeServerStatus() {
+        if (mediaRepository !is RemoteMediaRepository) return
+        mediaRepository.observeConnectionState()
+            .onEach { connectionState ->
+                val statusColor = when (connectionState) {
+                    is ServerConnectionState.Connected -> ServerStatusColor.Green
+                    // A mismatch needs attention as much as an outage does — the server the user
+                    // paired with is not the one answering.
+                    is ServerConnectionState.Unreachable,
+                    is ServerConnectionState.IdentityMismatch -> ServerStatusColor.Red
+                    // No server configured, or a check/lookup is still in flight. Showing red here
+                    // would report a problem the user does not have.
+                    ServerConnectionState.Unknown,
+                    ServerConnectionState.Checking,
+                    ServerConnectionState.Resolving -> ServerStatusColor.Unavailable
                 }
-                .launchIn(this)
-        }
+                _applicationUiState.update { uiState ->
+                    uiState.copy(serverStatusColor = statusColor)
+                }
+            }
+            .launchIn(this)
     }
 
     private fun getOverflowMenuOptions(): Set<OverflowMenuOption> {


### PR DESCRIPTION
Fixes #131. Also corrects #133, which was filed as an Android `ACCESS_LOCAL_NETWORK` bug but reproduces with the permission granted.

## The bug

`getHostIPv4()` took the first interface address matching a private prefix, and `NetworkInterface.getNetworkInterfaces()` enumerates in an order the OS chooses. On a machine with Parallels installed that order was:

```
bridge101 -> 10.37.129.2   <- picked
bridge100 -> 10.211.55.2
en0       -> 10.0.0.231    <- the actual LAN address
```

`isVirtual()` does not filter hypervisor bridges — it only reports subinterfaces like `en0:1`. The unroutable address was then persisted on the client *and* passed to `JmDNS.create()`, so mDNS was advertised only on the Parallels network. Discovery found nothing and direct connection timed out, both presenting as "the server is offline".

Address selection now prefers the address the OS routes outbound traffic through (resolved with an unconnected UDP socket, so no packets are sent), and excludes hypervisor and tunnel interfaces from the fallback scan.

## The underlying flaw

Fixing the pick only makes the *first* address correct. The real problem was that an IP address was serving as the identity of the connection: `ClientConfigEntity` stored a raw URL as the permanent key. An address is a DHCP lease — it changes on renewal, on moving between Wi-Fi and Ethernet, on a router reboot — and when it did, the client had no recovery path. Discovery could not help, because it stops browsing the moment a config row exists.

**The client now persists who the server is and resolves where it is.**

- The server mints a stable `serverId`, serves it from `GET /health`, and publishes it in structured mDNS TXT records (`id`, `v`, `name`, `scheme`, `addrs`). Keys and codec live in `core/model` so the two ends cannot drift.
- The client stores that identity instead of an address. `ServerEndpointResolver` tries the cached address, verifies the identity that answers, and re-browses mDNS when that fails, writing back whatever address it finds.
- Resolution is single-flight via a memoised `Deferred`, so six sync workers failing together trigger one browse, not six. Re-browsing is throttled to 30s.

A single `JmDNS` instance is used deliberately. One per interface makes jmdns rename the service to `"name (2)"` (`makeServiceNameUnique` compares port and SRV server fields), and both clients key their discovery map on the service name — so the multi-homed case it would help is the case it breaks. Every usable address goes in the `addrs` TXT property instead.

## Connection state

`Flow<Boolean>` becomes a sealed `ServerConnectionState`: `Unknown`, `Checking`, `Resolving`, `Connected`, `Unreachable(reason)`, `IdentityMismatch`.

This lets the UI distinguish "no server configured" from "server unreachable" — previously an unconfigured client showed a red status dot for a problem it did not have. `IdentityMismatch` is new behaviour: a reachable host that is **not** the paired server blocks uploads and stops polling, rather than sending photos to whoever now holds that address.

Manually entered pairings start with no identity and adopt whatever the server reports on the first successful probe, guarded in SQL (`AND server_id IS NULL`) so it can never repoint an already-identified client.

## Reviewer notes

- **Sync is untouched.** An earlier attempt to bound three unbounded waits broke sync on Android and was fully reverted — the wait in `LocalMediaManager` is load-bearing, as it is how a client launched before it has a server starts syncing once one is connected. Those files are byte-identical to `main` apart from one two-line delegating override the interface change requires. Concerns recorded in #139.
- **`MediaNetworkDataSource.checkServerHealth` was deleted**, not just simplified — it had zero callers once the connection state moved onto the resolver.
- **No backward compatibility path.** The project is unreleased, so the client talks only to `/health`; there is no fallback to the old liveness route.
- **`1.json` is regenerated** by KSP to match the new entity columns.
- **The AndroidManifest hunk** (removing the https TODO) was already staged in the working tree at the start of this work; that TODO is now tracked properly in #134.

## Testing

Compiles clean on Android, desktop JVM and iOS simulator; `:androidApp:assembleDebug` builds. **Not verified end to end** — no automated tests exist in the repo (#138), and device verification is outstanding.

Worth exercising:
- Onboard a client, then change the server's address without touching the client; it should re-resolve and return to connected with no user action.
- Point the client at a different server instance; it should report a mismatch and refuse to upload.
- Confirm the photo feed does not blank during re-resolution.

## Follow-ups filed

#134 auth and TLS (includes an unauthenticated path traversal in the chunk upload route) · #135 identity storage robustness · #136 dynamic port and multi-address · #137 Coil network fetcher · #138 test coverage · #139 sync behaviour on connection loss

Design summary with diagrams: `docs/server-discovery-refactor.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
