### PR TITLE
Resolve the server by identity instead of a stored IP (phased)

### DIFF
--- a/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/DesktopServerConfigManagerImpl.kt
+++ b/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/DesktopServerConfigManagerImpl.kt
@@ -15,6 +15,7 @@ import com.serratocreations.phovo.core.model.network.ApiEndpoints.LOW_RES_THUMBN
 import com.serratocreations.phovo.core.model.network.ApiEndpoints.SOURCE_FILE_API
 import com.serratocreations.phovo.data.photos.mappers.toMediaItemDto
 import com.serratocreations.phovo.core.serverconfig.DesktopServerConfigRepository
+import com.serratocreations.phovo.data.server.data.network.HostAddressDataSource
 import com.serratocreations.phovo.data.server.data.repository.ServerEventsRepository
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.absolutePath
@@ -56,8 +57,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.time.LocalDateTime
-import java.net.NetworkInterface
-import java.net.Inet4Address
 import java.net.InetAddress
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceInfo
@@ -70,6 +69,7 @@ class DesktopServerConfigManagerImpl(
     private val serverConfigRepository: DesktopServerConfigRepository,
     private val serverEventsRepository: ServerEventsRepository,
     private val localMediaRepository: LocalMediaRepository,
+    private val hostAddressDataSource: HostAddressDataSource,
     private val appScope: CoroutineScope,
     private val ioDispatcher: CoroutineDispatcher
 ): DesktopServerConfigManager {
@@ -87,22 +87,6 @@ class DesktopServerConfigManagerImpl(
                 System.err.println("Error shutting down JmDNS: ${e.message}")
             }
         })
-    }
-
-    private fun getHostIPv4(): String {
-        return try {
-            val interfaces = java.util.Collections.list(NetworkInterface.getNetworkInterfaces())
-            val candidates = interfaces
-                .filter { it.isUp && !it.isLoopback && !it.isVirtual }
-                .flatMap { ni -> java.util.Collections.list(ni.inetAddresses) }
-                .filterIsInstance<Inet4Address>()
-                .map { it.hostAddress }
-            candidates.firstOrNull { address ->
-                address.startsWith("192.") || address.startsWith("10.") || address.startsWith("172.")
-            } ?: candidates.firstOrNull() ?: "127.0.0.1"
-        } catch (e: Exception) {
-            "127.0.0.1"
-        }
     }
 
     override fun getDefaultServerName(): String {
@@ -326,7 +310,7 @@ class DesktopServerConfigManagerImpl(
                 embeddedServer(factory = Netty, port = 8080, host = "0.0.0.0", module = routingConfig)
                     .start(wait = false)
 
-                val hostIp = getHostIPv4()
+                val hostIp = hostAddressDataSource.hostIPv4()
                 log.i { "Starting JmDNS advertisement for server IP: $hostIp" }
                 try {
                     val inetAddress = InetAddress.getByName(hostIp)

--- a/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/network/HostAddressDataSource.kt
+++ b/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/data/network/HostAddressDataSource.kt
@@ -1,0 +1,111 @@
+package com.serratocreations.phovo.data.server.data.network
+
+import com.serratocreations.phovo.core.logger.PhovoLogger
+import java.net.DatagramSocket
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+
+/**
+ * Reads this machine's own network addresses from the host OS.
+ *
+ * Exists so the question "which of our addresses can a client on the LAN actually reach us at" has
+ * one answer in one place. Getting it wrong is silent: the address is published over mDNS and
+ * stored by every client, so an unroutable choice presents as a server that is simply offline.
+ */
+class HostAddressDataSource(
+    logger: PhovoLogger
+) {
+    private val log = logger.withTag("HostAddressDataSource")
+
+    private companion object {
+        /** Any off-link address will do; it is used for a route lookup and never contacted. */
+        const val ROUTE_LOOKUP_ADDRESS = "1.1.1.1"
+        const val ROUTE_LOOKUP_PORT = 53
+        // TODO Loopback is a placeholder, not an answer — no client can reach another machine's
+        //  loopback, so returning it turns "this host has no network" into an address that is
+        //  advertised and stored but can never work. Make hostIPv4() nullable and surface a
+        //  "no network connection" state instead, alongside the server-failed-to-start error.
+        const val LOOPBACK_ADDRESS = "127.0.0.1"
+    }
+
+    /**
+     * The IPv4 address clients on the LAN can actually reach this machine at.
+     *
+     * Interface enumeration order is not meaningful, and hypervisor bridges (Parallels, VMware,
+     * Docker) hand out private addresses indistinguishable from a real LAN address while being
+     * reachable only from this host. [NetworkInterface.isVirtual] does not identify them — it only
+     * reports subinterfaces such as `en0:1`.
+     *
+     * Rather than guessing from interface names, this prefers the address the OS itself routes
+     * outbound traffic through: that interface is by definition one this machine shares with
+     * others. [candidateAddresses] is only a fallback for when no default route exists.
+     */
+    fun hostIPv4(): String {
+        val candidates = candidateAddresses()
+        val defaultRouteAddress = defaultRouteIPv4()
+
+        log.i {
+            "Host IPv4 candidates: ${candidates.map { it.hostAddress }}, " +
+                "default route: ${defaultRouteAddress?.hostAddress}"
+        }
+
+        // The routed address is authoritative when it also survived the interface scan.
+        if (defaultRouteAddress != null && defaultRouteAddress in candidates) {
+            return defaultRouteAddress.hostAddress
+        }
+
+        // Otherwise the route leaves through an interface the scan rejected — a VPN tunnel, say —
+        // so fall back to a private address a client on the same LAN could route to.
+        return candidates.firstOrNull { it.isSiteLocalAddress }?.hostAddress
+            ?: defaultRouteAddress?.hostAddress
+            ?: candidates.firstOrNull()?.hostAddress
+            ?: LOOPBACK_ADDRESS
+    }
+
+    /**
+     * Every IPv4 address on an interface that could plausibly carry LAN traffic.
+     *
+     * Filters on interface capabilities rather than names: a point-to-point or non-multicast
+     * interface cannot serve mDNS discovery, whereas a name-based denylist would both miss new
+     * virtualization tools and wrongly exclude real interfaces — macOS Internet Sharing runs the
+     * LAN over `bridge100`.
+     */
+    fun candidateAddresses(): List<Inet4Address> = try {
+        NetworkInterface.getNetworkInterfaces().asSequence()
+            .filter { it.isUp && !it.isLoopback && !it.isVirtual && !it.isPointToPoint && it.supportsMulticast() }
+            .flatMap { it.inetAddresses.asSequence() }
+            .filterIsInstance<Inet4Address>()
+            .filter { it.isUsableHostAddress() }
+            .toList()
+    } catch (e: Exception) {
+        log.e(e) { "Unable to enumerate network interfaces" }
+        emptyList()
+    }
+
+    /**
+     * The local address the OS would use to reach the outside world — that is, the address on
+     * whichever interface holds the default route.
+     *
+     * The JDK cannot read the routing table, so this asks the kernel indirectly. Connecting a
+     * *UDP* socket performs a route lookup and binds the socket to the chosen local interface,
+     * but unlike TCP it sends no packets and needs no reachable peer, so this works offline.
+     * [ROUTE_LOOKUP_ADDRESS] is never contacted; it only has to be off-link so the lookup
+     * resolves via the default route rather than a directly attached one.
+     *
+     * @return null when there is no default route at all, leaving [candidateAddresses] to decide.
+     */
+    private fun defaultRouteIPv4(): Inet4Address? = try {
+        DatagramSocket().use { socket ->
+            socket.connect(InetAddress.getByName(ROUTE_LOOKUP_ADDRESS), ROUTE_LOOKUP_PORT)
+            (socket.localAddress as? Inet4Address)?.takeIf { it.isUsableHostAddress() }
+        }
+    } catch (e: Exception) {
+        log.e(e) { "Unable to resolve default route address" }
+        null
+    }
+
+    /** Excludes the wildcard, loopback and self-assigned (169.254.0.0/16) addresses. */
+    private fun Inet4Address.isUsableHostAddress(): Boolean =
+        !isAnyLocalAddress && !isLoopbackAddress && !isLinkLocalAddress
+}

--- a/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.desktop.kt
+++ b/data/server/src/jvmMain/kotlin/com/serratocreations/phovo/data/server/di/ServerDataModule.desktop.kt
@@ -7,6 +7,7 @@ import com.serratocreations.phovo.data.server.data.DesktopServerConfigManager
 import com.serratocreations.phovo.data.server.data.DesktopServerConfigManagerImpl
 import com.serratocreations.phovo.core.serverconfig.ServerConfigRepository
 import com.serratocreations.phovo.core.serverconfig.DesktopServerConfigRepository
+import com.serratocreations.phovo.data.server.data.network.HostAddressDataSource
 import com.serratocreations.phovo.data.server.data.repository.ServerEventsRepository
 import org.koin.dsl.binds
 import org.koin.dsl.module
@@ -20,14 +21,17 @@ internal actual fun getAndroidDesktopIosModules(): org.koin.core.module.Module =
 
     single { ServerEventsRepository() }
 
+    single { HostAddressDataSource(get()) }
+
     single {
         DesktopServerConfigManagerImpl(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(APPLICATION_SCOPE),
-            get(IO_DISPATCHER)
+            logger = get(),
+            serverConfigRepository = get(),
+            serverEventsRepository = get(),
+            localMediaRepository = get(),
+            hostAddressDataSource = get(),
+            appScope = get(APPLICATION_SCOPE),
+            ioDispatcher = get(IO_DISPATCHER)
         )
     } binds arrayOf(DesktopServerConfigManager::class)
 }


### PR DESCRIPTION
Replaces #140, which was correct but 44 files and not reviewable in one pass. Same destination, delivered as one commit per phase so each can be reviewed on its own. #140 stays open as a reference for the complete implementation until this lands.

**Review commit by commit** — each commit compiles on Android, desktop JVM and iOS simulator, and is independently sensible.

## Phases

| # | Phase | Status |
|---|---|---|
| 1 | Fix the address selection — fixes #131/#133 | ✅ in this PR |
| 2 | Ktor engine lifecycle (`BindException` on reconfigure) | pending |
| 3 | Network error classification (`NetworkFailure`) | pending |
| 4 | `ServerConnectionState` sealed type | pending |
| 5 | Server identity + `GET /health` | pending |
| 6 | mDNS TXT records | pending |
| 7a | `ServerEndpointResolver`, added additively | pending |
| 7b | Config carries identity instead of an address | pending |
| 8 | URL normalization for manual entry | pending |
| 9 | `GetClientConnectionUseCase` | pending |

## Why this sequence

The reported bug is fixed by phase 1 alone. Everything after it addresses the underlying design flaw: an IP address was being used as the *identity* of the connection, so any address change left the client with no recovery path and no way back — discovery stops the moment a config row exists.

Phases 2 and 3 are independent bug fixes that happen to be prerequisites. Phase 4 is a type change with a boolean shim so no behaviour moves. Phases 5 and 6 are server-side only; the client cannot yet use what they publish. Phase 7 is split because the resolver and the identity-carrying config are mutually dependent — landing the resolver additively first keeps each half reviewable.

## Testing

Compiles on all three platforms per commit. End-to-end verification is the author's; there is no automated test coverage in the repo (#138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
